### PR TITLE
imaginator: inject image stream variables and support SourceImage expansion.

### DIFF
--- a/imagebuilder/builder/addImage.go
+++ b/imagebuilder/builder/addImage.go
@@ -94,7 +94,7 @@ func buildFileSystemWithHasher(dirname string, h *hasher,
 
 func listPackages(rootDir string) ([]image.Package, error) {
 	output := new(bytes.Buffer)
-	err := runInTarget(nil, output, rootDir, packagerPathname,
+	err := runInTarget(nil, output, rootDir, nil, packagerPathname,
 		"show-size-multiplier")
 	if err != nil {
 		return nil, fmt.Errorf("error getting size multiplier: %s", err)
@@ -110,7 +110,7 @@ func listPackages(rootDir string) ([]image.Package, error) {
 		return nil, errors.New("malformed size multiplier")
 	}
 	output.Reset()
-	err = runInTarget(nil, output, rootDir, packagerPathname, "list")
+	err = runInTarget(nil, output, rootDir, nil, packagerPathname, "list")
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +258,7 @@ func runTest(rootDir, prog string) testResultType {
 	errChannel := make(chan error, 1)
 	timer := time.NewTimer(time.Second * 10)
 	go func() {
-		errChannel <- runInTarget(nil, &result, rootDir, packagerPathname,
+		errChannel <- runInTarget(nil, &result, rootDir, nil, packagerPathname,
 			"run", prog)
 	}()
 	select {

--- a/imagebuilder/builder/api.go
+++ b/imagebuilder/builder/api.go
@@ -20,6 +20,10 @@ type buildLogger interface {
 	io.Writer
 }
 
+type environmentGetter interface {
+	getenv() map[string]string
+}
+
 type imageBuilder interface {
 	build(b *Builder, client *srpc.Client, request proto.BuildImageRequest,
 		buildLog buildLogger) (*image.Image, error)
@@ -154,24 +158,24 @@ func BuildImageFromManifest(client *srpc.Client, manifestDir, streamName string,
 			StreamName: streamName,
 			ExpiresIn:  expiresIn,
 		},
-		bindMounts, buildLog)
+		bindMounts, nil, buildLog)
 	return name, err
 }
 
 func BuildTreeFromManifest(client *srpc.Client, manifestDir string,
 	bindMounts []string, buildLog io.Writer,
 	logger log.Logger) (string, error) {
-	return buildTreeFromManifest(client, manifestDir, bindMounts, buildLog)
+	return buildTreeFromManifest(client, manifestDir, bindMounts, nil, buildLog)
 }
 
 func ProcessManifest(manifestDir, rootDir string, bindMounts []string,
 	buildLog io.Writer) error {
-	return processManifest(manifestDir, rootDir, bindMounts, buildLog)
+	return processManifest(manifestDir, rootDir, bindMounts, nil, buildLog)
 }
 
 func UnpackImageAndProcessManifest(client *srpc.Client, manifestDir string,
 	rootDir string, bindMounts []string, buildLog io.Writer) error {
 	_, err := unpackImageAndProcessManifest(client, manifestDir, rootDir,
-		bindMounts, true, buildLog)
+		bindMounts, true, nil, buildLog)
 	return err
 }

--- a/imagebuilder/builder/build.go
+++ b/imagebuilder/builder/build.go
@@ -69,7 +69,7 @@ func (b *Builder) rebuildImages(minInterval time.Duration) {
 		sleepUntil = time.Now().Add(minInterval)
 		client, err := srpc.DialHTTP("tcp", b.imageServerAddress, 0)
 		if err != nil {
-			b.logger.Println(err)
+			b.logger.Printf("%s: %s\n", b.imageServerAddress, err)
 			continue
 		}
 		for _, streamName := range b.listStreamsToAutoRebuild() {

--- a/imagebuilder/builder/html.go
+++ b/imagebuilder/builder/html.go
@@ -208,14 +208,17 @@ func (stream *imageStreamType) WriteHtml(writer io.Writer) {
 		fmt.Fprintf(writer, "<b>%s</b><br>\n", err)
 		return
 	}
-	sourceStream := stream.builder.getHtmlWriter(manifest.SourceImage)
-	if sourceStream == nil {
+	sourceImageName := os.Expand(manifest.SourceImage,
+		func(name string) string {
+			return stream.getenv()[name]
+		})
+	if stream.builder.getHtmlWriter(sourceImageName) == nil {
 		fmt.Fprintf(writer, "SourceImage: <code>%s</code><br>\n",
-			manifest.SourceImage)
+			sourceImageName)
 	} else {
 		fmt.Fprintf(writer,
 			"SourceImage: <a href=\"showImageStream?%s\"><code>%s</code></a><br>\n",
-			manifest.SourceImage, manifest.SourceImage)
+			sourceImageName, sourceImageName)
 	}
 	fmt.Fprintln(writer, "Contents of <code>manifest</code> file:<br>")
 	fmt.Fprintf(writer, "<pre style=\"%s\">\n", codeStyle)

--- a/imagebuilder/builder/image.go
+++ b/imagebuilder/builder/image.go
@@ -45,6 +45,7 @@ func (stream *imageStreamType) build(b *Builder, client *srpc.Client,
 func (stream *imageStreamType) getenv() map[string]string {
 	envTable := make(map[string]string, 1)
 	envTable["IMAGE_STREAM"] = stream.name
+	envTable["IMAGE_STREAM_LEAF_NAME"] = filepath.Base(stream.name)
 	return envTable
 }
 

--- a/imagebuilder/builder/image.go
+++ b/imagebuilder/builder/image.go
@@ -55,10 +55,7 @@ func (stream *imageStreamType) getManifest(b *Builder, streamName string,
 	if gitBranch == "" {
 		gitBranch = "master"
 	}
-	variableFunc := b.getVariableFunc(map[string]string{
-		"IMAGE_STREAM": streamName,
-	},
-		variables)
+	variableFunc := b.getVariableFunc(stream.getenv(), variables)
 	manifestRoot, err := makeTempDirectory("",
 		strings.Replace(streamName, "/", "_", -1)+".manifest")
 	if err != nil {

--- a/imagebuilder/builder/image.go
+++ b/imagebuilder/builder/image.go
@@ -35,11 +35,17 @@ func (stream *imageStreamType) build(b *Builder, client *srpc.Client,
 	}
 	defer os.RemoveAll(manifestDirectory)
 	img, err := buildImageFromManifest(client, manifestDirectory, request,
-		b.bindMounts, buildLog)
+		b.bindMounts, stream, buildLog)
 	if err != nil {
 		return nil, err
 	}
 	return img, nil
+}
+
+func (stream *imageStreamType) getenv() map[string]string {
+	envTable := make(map[string]string, 1)
+	envTable["IMAGE_STREAM"] = stream.name
+	return envTable
 }
 
 func (stream *imageStreamType) getManifest(b *Builder, streamName string,
@@ -213,7 +219,7 @@ func runCommand(buildLog io.Writer, cwd string, args ...string) error {
 
 func buildImageFromManifest(client *srpc.Client, manifestDir string,
 	request proto.BuildImageRequest, bindMounts []string,
-	buildLog buildLogger) (*image.Image, error) {
+	envGetter environmentGetter, buildLog buildLogger) (*image.Image, error) {
 	// First load all the various manifest files (fail early on error).
 	computedFilesList, err := util.LoadComputedFiles(
 		path.Join(manifestDir, "computed-files.json"))
@@ -240,7 +246,7 @@ func buildImageFromManifest(client *srpc.Client, manifestDir string,
 	defer os.RemoveAll(rootDir)
 	fmt.Fprintf(buildLog, "Created image working directory: %s\n", rootDir)
 	manifest, err := unpackImageAndProcessManifest(client, manifestDir,
-		rootDir, bindMounts, false, buildLog)
+		rootDir, bindMounts, false, envGetter, buildLog)
 	if err != nil {
 		return nil, err
 	}
@@ -274,9 +280,10 @@ func buildImageFromManifest(client *srpc.Client, manifestDir string,
 
 func buildImageFromManifestAndUpload(client *srpc.Client, manifestDir string,
 	request proto.BuildImageRequest, bindMounts []string,
+	envGetter environmentGetter,
 	buildLog buildLogger) (*image.Image, string, error) {
 	img, err := buildImageFromManifest(client, manifestDir, request, bindMounts,
-		buildLog)
+		envGetter, buildLog)
 	if err != nil {
 		return nil, "", err
 	}
@@ -288,13 +295,14 @@ func buildImageFromManifestAndUpload(client *srpc.Client, manifestDir string,
 }
 
 func buildTreeFromManifest(client *srpc.Client, manifestDir string,
-	bindMounts []string, buildLog io.Writer) (string, error) {
+	bindMounts []string, envGetter environmentGetter,
+	buildLog io.Writer) (string, error) {
 	rootDir, err := makeTempDirectory("", "tree")
 	if err != nil {
 		return "", err
 	}
 	_, err = unpackImageAndProcessManifest(client, manifestDir, rootDir,
-		bindMounts, true, buildLog)
+		bindMounts, true, envGetter, buildLog)
 	if err != nil {
 		os.RemoveAll(rootDir)
 		return "", err

--- a/imagebuilder/builder/load.go
+++ b/imagebuilder/builder/load.go
@@ -149,7 +149,7 @@ func (b *Builder) delayMakeRequiredDirectories(abortNotifier <-chan struct{}) {
 func (b *Builder) makeRequiredDirectories() error {
 	imageServer, err := srpc.DialHTTP("tcp", b.imageServerAddress, 0)
 	if err != nil {
-		b.logger.Println(err)
+		b.logger.Printf("%s: %s\n", b.imageServerAddress, err)
 		return nil
 	}
 	defer imageServer.Close()

--- a/imagebuilder/builder/processManifest.go
+++ b/imagebuilder/builder/processManifest.go
@@ -97,7 +97,13 @@ func unpackImageAndProcessManifest(client *srpc.Client, manifestDir string,
 		return manifestType{},
 			errors.New("error reading manifest file: " + err.Error())
 	}
-	sourceImageInfo, err := unpackImage(client, manifestConfig.SourceImage,
+	sourceImageName := manifestConfig.SourceImage
+	if envGetter != nil {
+		sourceImageName = os.Expand(sourceImageName, func(name string) string {
+			return envGetter.getenv()[name]
+		})
+	}
+	sourceImageInfo, err := unpackImage(client, sourceImageName,
 		0, 0, rootDir, buildLog)
 	if err != nil {
 		return manifestType{},

--- a/imagebuilder/builder/processManifest.go
+++ b/imagebuilder/builder/processManifest.go
@@ -90,7 +90,7 @@ func makeMountPoints(rootDir string, bindMounts []string,
 
 func unpackImageAndProcessManifest(client *srpc.Client, manifestDir string,
 	rootDir string, bindMounts []string, applyFilter bool,
-	buildLog io.Writer) (manifestType, error) {
+	envGetter environmentGetter, buildLog io.Writer) (manifestType, error) {
 	manifestFile := filepath.Join(manifestDir, "manifest")
 	var manifestConfig manifestConfigType
 	if err := json.ReadFromFile(manifestFile, &manifestConfig); err != nil {
@@ -104,7 +104,7 @@ func unpackImageAndProcessManifest(client *srpc.Client, manifestDir string,
 			errors.New("error unpacking image: " + err.Error())
 	}
 	startTime := time.Now()
-	err = processManifest(manifestDir, rootDir, bindMounts, buildLog)
+	err = processManifest(manifestDir, rootDir, bindMounts, envGetter, buildLog)
 	if err != nil {
 		return manifestType{},
 			errors.New("error processing manifest: " + err.Error())
@@ -121,7 +121,7 @@ func unpackImageAndProcessManifest(client *srpc.Client, manifestDir string,
 }
 
 func processManifest(manifestDir, rootDir string, bindMounts []string,
-	buildLog io.Writer) error {
+	envGetter environmentGetter, buildLog io.Writer) error {
 	if err := copyFiles(manifestDir, "files", rootDir, buildLog); err != nil {
 		return err
 	}
@@ -139,8 +139,8 @@ func processManifest(manifestDir, rootDir string, bindMounts []string,
 		return err
 	}
 	defer file.Close()
-	err = runInTarget(file, buildLog, rootDir, packagerPathname, "copy-in",
-		"/etc/resolv.conf")
+	err = runInTarget(file, buildLog, rootDir, envGetter, packagerPathname,
+		"copy-in", "/etc/resolv.conf")
 	if err != nil {
 		return fmt.Errorf("error copying in /etc/resolv.conf: %s", err)
 	}
@@ -152,17 +152,17 @@ func processManifest(manifestDir, rootDir string, bindMounts []string,
 		}
 	}
 	if len(packageList) > 0 {
-		err := updatePackageDatabase(rootDir, bindMounts, buildLog)
+		err := updatePackageDatabase(rootDir, bindMounts, envGetter, buildLog)
 		if err != nil {
 			return err
 		}
 	}
 	err = runScripts(manifestDir, "pre-install-scripts", rootDir, bindMounts,
-		buildLog)
+		envGetter, buildLog)
 	if err != nil {
 		return err
 	}
-	err = installPackages(packageList, rootDir, bindMounts, buildLog)
+	err = installPackages(packageList, rootDir, bindMounts, envGetter, buildLog)
 	if err != nil {
 		return errors.New("error installing packages: " + err.Error())
 	}
@@ -170,7 +170,8 @@ func processManifest(manifestDir, rootDir string, bindMounts []string,
 	if err != nil {
 		return err
 	}
-	err = runScripts(manifestDir, "scripts", rootDir, bindMounts, buildLog)
+	err = runScripts(manifestDir, "scripts", rootDir, bindMounts, envGetter,
+		buildLog)
 	if err != nil {
 		return err
 	}
@@ -217,7 +218,7 @@ func copyFile(destFilename, sourceFilename string, mode os.FileMode,
 }
 
 func installPackages(packageList []string, rootDir string, bindMounts []string,
-	buildLog io.Writer) error {
+	envGetter environmentGetter, buildLog io.Writer) error {
 	if len(packageList) < 1 { // Nothing to do.
 		fmt.Fprintln(buildLog, "\nNo packages to install")
 		return nil
@@ -225,7 +226,7 @@ func installPackages(packageList []string, rootDir string, bindMounts []string,
 	fmt.Fprintln(buildLog, "\nUpgrading packages:")
 	startTime := time.Now()
 	err := runInTargetWithBindMounts(nil, buildLog, rootDir, bindMounts,
-		packagerPathname, "upgrade")
+		envGetter, packagerPathname, "upgrade")
 	if err != nil {
 		return errors.New("error upgrading: " + err.Error())
 	}
@@ -238,7 +239,7 @@ func installPackages(packageList []string, rootDir string, bindMounts []string,
 	args := []string{"install"}
 	args = append(args, packageList...)
 	err = runInTargetWithBindMounts(nil, buildLog, rootDir, bindMounts,
-		packagerPathname, args...)
+		envGetter, packagerPathname, args...)
 	if err != nil {
 		return errors.New("error installing: " + err.Error())
 	}
@@ -248,7 +249,7 @@ func installPackages(packageList []string, rootDir string, bindMounts []string,
 }
 
 func runScripts(manifestDir, dirname, rootDir string, bindMounts []string,
-	buildLog io.Writer) error {
+	envGetter environmentGetter, buildLog io.Writer) error {
 	scriptsDir := filepath.Join(manifestDir, dirname)
 	file, err := os.Open(scriptsDir)
 	if err != nil {
@@ -290,7 +291,8 @@ func runScripts(manifestDir, dirname, rootDir string, bindMounts []string,
 		fmt.Fprintf(buildLog, "Running script: %s\n", name)
 		startTime := time.Now()
 		err := runInTargetWithBindMounts(nil, buildLog, rootDir, bindMounts,
-			packagerPathname, "run", filepath.Join("/.scripts", name))
+			envGetter, packagerPathname, "run",
+			filepath.Join("/.scripts", name))
 		if err != nil {
 			return errors.New("error running script: " + name + ": " +
 				err.Error())
@@ -307,11 +309,11 @@ func runScripts(manifestDir, dirname, rootDir string, bindMounts []string,
 }
 
 func updatePackageDatabase(rootDir string, bindMounts []string,
-	buildLog io.Writer) error {
+	envGetter environmentGetter, buildLog io.Writer) error {
 	fmt.Fprintln(buildLog, "\nUpdating package database:")
 	startTime := time.Now()
 	err := runInTargetWithBindMounts(nil, buildLog, rootDir, bindMounts,
-		packagerPathname, "update")
+		envGetter, packagerPathname, "update")
 	if err != nil {
 		return errors.New("error updating: " + err.Error())
 	}


### PR DESCRIPTION
This change supports improved parameterisation of image manifests. This will help with sharing common manifests for different architectures (i.e. amd64 and i363).