### PR TITLE
Add branch name to image

### DIFF
--- a/imagebuilder/builder/addImage.go
+++ b/imagebuilder/builder/addImage.go
@@ -54,7 +54,11 @@ func addImage(client *srpc.Client, request proto.BuildImageRequest,
 	if request.ExpiresIn > 0 {
 		img.ExpiresAt = time.Now().Add(request.ExpiresIn)
 	}
-	name := path.Join(request.StreamName, time.Now().Format(timeFormat))
+	gitBranch := request.GitBranch
+	if gitBranch == "master" {
+		gitBranch = ""
+	}
+	name := path.Join(request.StreamName, gitBranch, time.Now().Format(timeFormat))
 	if err := imageclient.AddImage(client, name, img); err != nil {
 		return "", errors.New("remote error: " + err.Error())
 	}


### PR DESCRIPTION
This adds branch names to images to make it more easy to see what branches
are being build from non-master branches. Possibly this should be enabled via a flag in order to not break existing workflows.
