### PR TITLE
Allow configuration of resolv conf

### DIFF
--- a/imagebuilder/builder/processManifest.go
+++ b/imagebuilder/builder/processManifest.go
@@ -139,6 +139,7 @@ func processManifest(manifestDir, rootDir string, bindMounts []string,
 	if err != nil {
 		return fmt.Errorf("error copying in /etc/resolv.conf: %s", err)
 	}
+	fmt.Fprintf(buildLog, "Copied in hosts /etc/resolv.conf\n")
 	if err := copyFiles(manifestDir, "files", rootDir, buildLog); err != nil {
 		return err
 	}

--- a/imagebuilder/builder/processManifest.go
+++ b/imagebuilder/builder/processManifest.go
@@ -128,17 +128,6 @@ func unpackImageAndProcessManifest(client *srpc.Client, manifestDir string,
 
 func processManifest(manifestDir, rootDir string, bindMounts []string,
 	envGetter environmentGetter, buildLog io.Writer) error {
-	if err := copyFiles(manifestDir, "files", rootDir, buildLog); err != nil {
-		return err
-	}
-	for index, bindMount := range bindMounts {
-		bindMounts[index] = filepath.Clean(bindMount)
-	}
-	directoriesToDelete, err := makeMountPoints(rootDir, bindMounts, buildLog)
-	if err != nil {
-		return err
-	}
-	defer deleteDirectories(directoriesToDelete)
 	// Copy in system /etc/resolv.conf
 	file, err := os.Open("/etc/resolv.conf")
 	if err != nil {
@@ -150,6 +139,17 @@ func processManifest(manifestDir, rootDir string, bindMounts []string,
 	if err != nil {
 		return fmt.Errorf("error copying in /etc/resolv.conf: %s", err)
 	}
+	if err := copyFiles(manifestDir, "files", rootDir, buildLog); err != nil {
+		return err
+	}
+	for index, bindMount := range bindMounts {
+		bindMounts[index] = filepath.Clean(bindMount)
+	}
+	directoriesToDelete, err := makeMountPoints(rootDir, bindMounts, buildLog)
+	if err != nil {
+		return err
+	}
+	defer deleteDirectories(directoriesToDelete)
 	packageList, err := fsutil.LoadLines(filepath.Join(manifestDir,
 		"package-list"))
 	if err != nil {

--- a/imagebuilder/builder/processManifest.go
+++ b/imagebuilder/builder/processManifest.go
@@ -189,9 +189,6 @@ func processManifest(manifestDir, rootDir string, bindMounts []string,
 	if err := cleanPackages(rootDir, buildLog); err != nil {
 		return err
 	}
-	if err := clearResolvConf(buildLog, rootDir); err != nil {
-		return err
-	}
 	return deleteDirectories(directoriesToDelete)
 }
 


### PR DESCRIPTION
This is a proposed solution for https://github.com/Cloud-Foundations/Dominator/issues/44. This will let you add a resolv.conf via the files folder and have it not be overwritten. The copy of /dev/null to /etc/resolv.conf at the end of process manifest is remove so you are able to have this propagate to your final image.

I have tested this in our environment and can see that resolv.conf added through the files folder ends up on a host after applied.

I don't believe this could break anyones current process as if they don't have /etc/resolv.conf in the filters file dominator would just try to enforce an empty file. Additionally if they are using a computed-file for this the inode will be replaced anyway. I could be missing some edge case.