### PR TITLE
imaginator: allow resolv.conf to be injected and output from build.

### DIFF
--- a/lib/html/api.go
+++ b/lib/html/api.go
@@ -44,6 +44,18 @@ func NewTableWriter(writer io.Writer, doHighlighting bool,
 	return newTableWriter(writer, doHighlighting, columns)
 }
 
+func (tw *TableWriter) CloseRow() error {
+	return tw.closeRow()
+}
+
+func (tw *TableWriter) OpenRow(foreground, background string) error {
+	return tw.openRow(foreground, background)
+}
+
+func (tw *TableWriter) WriteData(foreground, data string) error {
+	return tw.writeData(foreground, data)
+}
+
 func (tw *TableWriter) WriteRow(foreground, background string,
 	columns ...string) error {
 	return tw.writeRow(foreground, background, columns)


### PR DESCRIPTION
If `/etc/resolv.conf` is in the `files` tree, it will override the host-provided one during the build.

If `/etc/resolv.conf` is in the `post-scripts-files` tree, it will be output in the image rather than being empty.

This fixes issue #44 and replaces PR #45.