### PR TITLE
filegen locks to avoid concurrent map read+write

### DIFF
--- a/lib/filegen/register.go
+++ b/lib/filegen/register.go
@@ -44,7 +44,9 @@ func (m *Manager) registerHashGeneratorForPath(pathname string,
 
 func (m *Manager) processPathDataInvalidations(pathname string,
 	machineNameChannel <-chan string) {
+	m.rwMutex.RLock()
 	pathMgr := m.pathManagers[pathname]
+	m.rwMutex.RUnlock()
 	for machineName := range machineNameChannel {
 		pathMgr.rwMutex.Lock()
 		if machineName == "" {


### PR DESCRIPTION
filegen has been observed to sometimes panic with the following error when registering several watches in a row.

each "register" call starts a goroutine which goes on to read from a map.

```
fatal error: concurrent map read and map write
 goroutine 158 [running]:
 runtime.throw(0x1405d8f, 0x21)
         GOROOT/src/runtime/panic.go:774 +0x72 fp=0xc0006d0ae0 sp=0xc0006d0ab0 pc=0x42f562
 runtime.mapaccess1_faststr(0x11c27a0, 0xc000737ef0, 0x1417f88, 0x2d, 0x0)
         GOROOT/src/runtime/map_faststr.go:21 +0x44f fp=0xc0006d0b50 sp=0xc0006d0ae0 pc=0x412baf
 github.com/Symantec/Dominator/lib/filegen.(*Manager).processPathDataInvalidations(0xc0004b54f0, 0x1417f88, 0x2d, 0xc000724360)
         external/com_github_symantec_dominator/lib/filegen/register.go:47 +0x6d fp=0xc0006d0fc0 sp=0xc0006d0b50 pc=0x102449d
 runtime.goexit()
         src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0006d0fc8 sp=0xc0006d0fc0 pc=0x45f111
 created by github.com/Symantec/Dominator/lib/filegen.(*Manager).registerHashGeneratorForPath
         external/com_github_symantec_dominator/lib/filegen/register.go:41 +0x15d
```