### PR TITLE
Improve image life-cycle management for SmallStack VMs.

### DIFF
--- a/cmd/imagetool/main.go
+++ b/cmd/imagetool/main.go
@@ -146,6 +146,7 @@ var subcommands = []commands.Command{
 	{"merge-triggers", "     triggers-file...", 1, -1, mergeTriggersSubcommand},
 	{"mkdir", "              name", 1, 1, makeDirectorySubcommand},
 	{"show", "               name", 1, 1, showImageSubcommand},
+	{"show-filter", "               name", 1, 1, showImageFilterSubcommand},
 	{"showunrefobj", "", 0, 0, showUnreferencedObjectsSubcommand},
 	{"tar", "                name [file]", 1, 2, tarImageSubcommand},
 	{"test-download-speed", "name", 1, 1, testDownloadSpeedSubcommand},

--- a/cmd/imagetool/showImageFilter.go
+++ b/cmd/imagetool/showImageFilter.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/Cloud-Foundations/Dominator/lib/log"
+	"github.com/Cloud-Foundations/Dominator/proto/imageserver"
+)
+
+func showImageFilterSubcommand(args []string, logger log.DebugLogger) error {
+	if err := showImageFilter(args[0]); err != nil {
+		return fmt.Errorf("Error showing image filter: %s", err)
+	}
+	return nil
+}
+
+func showImageFilter(imageName string) error {
+	imageSClient, _ := getClients()
+	request := imageserver.GetImageRequest{
+		ImageName:        imageName,
+		IgnoreFilesystem: true,
+		Timeout:          *timeout,
+	}
+	var reply imageserver.GetImageResponse
+	err := imageSClient.RequestReply("ImageServer.GetImage", request, &reply)
+	if err != nil {
+		return err
+	}
+	if reply.Image == nil {
+		return fmt.Errorf("no image")
+	}
+	if reply.Image.Filter == nil {
+		return fmt.Errorf("no filter")
+	}
+	for _, line := range reply.Image.Filter.FilterLines {
+		fmt.Println(line)
+	}
+	return nil
+}

--- a/cmd/vm-control/main.go
+++ b/cmd/vm-control/main.go
@@ -76,6 +76,8 @@ var (
 	requestIPs   flagutil.StringList
 	roundupPower = flag.Uint64("roundupPower", 28,
 		"power of 2 to round up root volume size")
+	scanFilename = flag.String("scanFilename", "",
+		"Name of file to write scanned VM root to")
 	snapshotRootOnly = flag.Bool("snapshotRootOnly", false,
 		"If true, snapshot only the root volume")
 	traceMetadata = flag.Bool("traceMetadata", false,
@@ -164,6 +166,7 @@ var subcommands = []commands.Command{
 	{"set-vm-migrating", "IPaddr", 1, 1, setVmMigratingSubcommand},
 	{"snapshot-vm", "IPaddr", 1, 1, snapshotVmSubcommand},
 	{"save-vm", "IPaddr destination", 2, 2, saveVmSubcommand},
+	{"scan-vm-root", "IPaddr", 1, 1, scanVmRootSubcommand},
 	{"start-vm", "IPaddr", 1, 1, startVmSubcommand},
 	{"stop-vm", "IPaddr", 1, 1, stopVmSubcommand},
 	{"trace-vm-metadata", "IPaddr", 1, 1, traceVmMetadataSubcommand},

--- a/cmd/vm-control/scanVmRoot.go
+++ b/cmd/vm-control/scanVmRoot.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"encoding/gob"
+	"fmt"
+	"net"
+
+	hyperclient "github.com/Cloud-Foundations/Dominator/hypervisor/client"
+	"github.com/Cloud-Foundations/Dominator/lib/fsutil"
+	"github.com/Cloud-Foundations/Dominator/lib/log"
+	_ "github.com/Cloud-Foundations/Dominator/proto/sub"
+)
+
+func scanVmRootSubcommand(args []string, logger log.DebugLogger) error {
+	if err := scanVmRoot(args[0], logger); err != nil {
+		return fmt.Errorf("Error scanning VM root: %s", err)
+	}
+	return nil
+}
+
+func scanVmRoot(vmHostname string, logger log.DebugLogger) error {
+	if vmIP, hypervisor, err := lookupVmAndHypervisor(vmHostname); err != nil {
+		return err
+	} else {
+		return scanVmRootOnHypervisor(hypervisor, vmIP, logger)
+	}
+}
+
+func scanVmRootOnHypervisor(hypervisor string, ipAddr net.IP,
+	logger log.DebugLogger) error {
+	if *scanFilename == "" {
+		return fmt.Errorf("no scanFilename specified")
+	}
+	client, err := dialHypervisor(hypervisor)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	fs, err := hyperclient.ScanVmRoot(client, ipAddr, nil)
+	if err != nil {
+		return err
+	}
+	file, err := fsutil.CreateRenamingWriter(*scanFilename,
+		fsutil.PublicFilePerms)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	writer := bufio.NewWriter(file)
+	defer writer.Flush()
+	if err := gob.NewEncoder(writer).Encode(fs); err != nil {
+		file.Abort()
+		return err
+	}
+	return writer.Flush()
+}

--- a/hypervisor/manager/api.go
+++ b/hypervisor/manager/api.go
@@ -80,6 +80,7 @@ type vmInfoType struct {
 	serialInput                io.Writer
 	serialOutput               chan<- byte
 	stoppedNotifier            chan<- struct{}
+	updating                   bool
 	proto.LocalVmInfo
 }
 

--- a/lib/objectserver/cachingreader/api.go
+++ b/lib/objectserver/cachingreader/api.go
@@ -44,6 +44,10 @@ func NewObjectServer(baseDir string, maxCachedBytes uint64,
 	return newObjectServer(baseDir, maxCachedBytes, objectServerAddress, logger)
 }
 
+func (objSrv *ObjectServer) FetchObjects(hashes []hash.Hash) error {
+	return objSrv.fetchObjects(hashes)
+}
+
 func (objSrv *ObjectServer) GetObjects(hashes []hash.Hash) (
 	objectserver.ObjectsReader, error) {
 	return objSrv.getObjects(hashes)


### PR DESCRIPTION
Support patching or replacing images of running VMs by fetching/prefetching objects and restarting VM. In general, this will allow an imageserver VM to be upgraded even if the Hypervisor depends on that same VM for images.

Improve tooling to make it easier to scan remote VMs and diff against an image.