### PR TITLE
Fix leaking goroutines in filegen client

### DIFF
--- a/lib/filegen/client/machine.go
+++ b/lib/filegen/client/machine.go
@@ -133,6 +133,7 @@ func waitForObjectsAndSendUpdate(objectChannel <-chan hash.Hash,
 		delete(objectsToWaitFor, hashVal)
 		if len(objectsToWaitFor) < 1 {
 			updateChannel <- files // This will panic if the machine went away.
+			return
 		}
 	}
 }


### PR DESCRIPTION
I noticed that `filegen/client/num-object-waiters` was ever increasing when looking into some other issues around some slowness in some of our generated files. This turned out to be a non issue but adding this in will make sure the goroutine terminates when all the files have been returned instead of waiting for the next message to be sent on the channel which will never come.