### PR TITLE
Access control fixes.

### DIFF
--- a/dom/herd/sub.go
+++ b/dom/herd/sub.go
@@ -57,13 +57,26 @@ func (sub *Sub) address() string {
 }
 
 // Returns true if the principal described by authInfo has administrative access
-// to the sub.
+// to the sub. It checks for method access, then ownership listed in the MDB
+// data and then the sub configuration.
 func (sub *Sub) checkAdminAccess(authInfo *srpc.AuthInformation) bool {
 	if authInfo == nil {
 		return false
 	}
 	if authInfo.HaveMethodAccess {
 		return true
+	}
+	for _, group := range sub.mdb.OwnerGroups {
+		if _, ok := authInfo.GroupList[group]; ok {
+			return true
+		}
+	}
+	if authInfo.Username != "" {
+		for _, user := range sub.mdb.OwnerUsers {
+			if user == authInfo.Username {
+				return true
+			}
+		}
 	}
 	if sub.clientResource == nil {
 		return false

--- a/imageserver/rpcd/expiration.go
+++ b/imageserver/rpcd/expiration.go
@@ -24,15 +24,17 @@ func (t *srpcType) ChangeImageExpiration(conn *srpc.Conn,
 		msg = fmt.Sprintf("expire in %s",
 			format.Duration(time.Until(request.ExpiresAt)))
 	}
-	if username := conn.Username(); username == "" {
-		t.logger.Printf("ChangeImageExpiration(%s) %s\n",
-			request.ImageName, msg)
-	} else {
-		t.logger.Printf("ChangeImageExpiration(%s) %s by %s\n",
-			request.ImageName, msg, username)
-	}
 	_, err := t.imageDataBase.ChangeImageExpiration(
 		request.ImageName, request.ExpiresAt, conn.GetAuthInformation())
+	if err == nil {
+		if username := conn.Username(); username == "" {
+			t.logger.Printf("ChangeImageExpiration(%s) %s\n",
+				request.ImageName, msg)
+		} else {
+			t.logger.Printf("ChangeImageExpiration(%s) %s by %s\n",
+				request.ImageName, msg, username)
+		}
+	}
 	reply.Error = errors.ErrorToString(err)
 	return nil
 }

--- a/imageserver/scanner/imdb.go
+++ b/imageserver/scanner/imdb.go
@@ -210,7 +210,11 @@ func (imdb *ImageDataBase) checkDirectory(name string) bool {
 func (imdb *ImageDataBase) checkExpiration(expiresAt time.Time,
 	authInfo *srpc.AuthInformation) error {
 	if expiresAt.IsZero() {
-		return nil
+		if authInfo.HaveMethodAccess ||
+			authInfo.Username == "" { // Internal call.
+			return nil
+		}
+		return errors.New("not permitted to make image non-expiring")
 	}
 	expiresIn := time.Until(expiresAt)
 	if authInfo != nil && authInfo.HaveMethodAccess {

--- a/lib/srpc/api.go
+++ b/lib/srpc/api.go
@@ -474,16 +474,17 @@ type Conn struct {
 	Decoder
 	Encoder
 	*bufio.ReadWriter
-	conn             net.Conn
-	groupList        map[string]struct{}
-	haveMethodAccess bool
-	isEncrypted      bool
-	localAddr        string
-	parent           *Client             // nil: server-side connection.
-	permittedMethods map[string]struct{} // nil: all, empty: none permitted.
-	releaseNotifier  func()
-	remoteAddr       string
-	username         string // Empty string for unauthenticated.
+	allowMethodPowers bool
+	conn              net.Conn
+	groupList         map[string]struct{}
+	haveMethodAccess  bool
+	isEncrypted       bool
+	localAddr         string
+	parent            *Client             // nil: server-side connection.
+	permittedMethods  map[string]struct{} // nil: all, empty: none permitted.
+	releaseNotifier   func()
+	remoteAddr        string
+	username          string // Empty string for unauthenticated.
 }
 
 // Close will close the connection to the Sevice.Method function, releasing the


### PR DESCRIPTION
- lib/srpc: ignore SmallStack VM owner powers when user asks to ignore method powers
- Imageserver: fix permission check when making image non-expiring
- **Dominator**: check MDB ownerships when checking for admin access to sub.