### PR TITLE
hypervisor/manager: use new syntax for watchdog

### DIFF
--- a/hypervisor/manager/qemuStart.go
+++ b/hypervisor/manager/qemuStart.go
@@ -174,7 +174,7 @@ func (vm *vmInfoType) startQemuVm(enableNetboot, haveManagerLock bool,
 	if vm.WatchdogModel != proto.WatchdogModelNone {
 		cmd.Args = append(cmd.Args,
 			"-watchdog-action", vm.WatchdogAction.String(),
-			"-watchdog", vm.WatchdogModel.String())
+			"-device", vm.WatchdogModel.String())
 	}
 	os.Remove(filepath.Join(vm.dirname, "bootlog"))
 	cmd.Env = os.Environ()


### PR DESCRIPTION
The old QEMU syntax for giving the guest a watchdog device (the -watchdog flag) is broken as of QEMU 7.2 [1]. Since Ubuntu 22 uses Qemu 6.2 while Ubuntu 24 uses 8.2, upgrading a hypervisor from Ubuntu 22 to Ubuntu 24 prevents VMs that use watchdogs from starting. The new syntax for giving guests watchdogs seems to have been supported for around 16 years [2], so unconditionally pivot to using the new syntax.

[1] https://wiki.qemu.org/ChangeLog/7.2
[2] https://github.com/qemu/qemu/blame/master/docs/qdev-device-use.txt#L354