### PR TITLE
Allow VMs to be created without writing zeroes to file if fallocate operation is not available.

### DIFF
--- a/cmd/hypervisor/main.go
+++ b/cmd/hypervisor/main.go
@@ -35,6 +35,8 @@ const (
 var (
 	dhcpServerOnBridgesOnly = flag.Bool("dhcpServerOnBridgesOnly", false,
 		"If true, run the DHCP server on bridge interfaces only")
+	disableFillZero = flag.Bool("disableFillZero", false,
+		"If true, skip operation to write zeroes to file when fallocate is not available")
 	identityProvider = flag.String("identityProvider", "",
 		"Base URL of identity provider which can issue role certificates")
 	imageServerHostname = flag.String("imageServerHostname", "localhost",
@@ -186,6 +188,7 @@ func run() {
 	managerObj, err := manager.New(manager.StartOptions{
 		BridgeMap:            bridgeMap,
 		DhcpServer:           dhcpServer,
+		DisableFillZero:      *disableFillZero,
 		IdentityProvider:     *identityProvider,
 		ImageServerAddress:   imageServerAddress,
 		LockCheckInterval:    *lockCheckInterval,

--- a/hypervisor/manager/api.go
+++ b/hypervisor/manager/api.go
@@ -81,6 +81,7 @@ type Manager struct {
 type StartOptions struct {
 	BridgeMap            map[string]net.Interface // Key: interface name.
 	DhcpServer           DhcpServer
+	DisableFillZero      bool
 	IdentityProvider     string
 	ImageServerAddress   string
 	LockCheckInterval    time.Duration

--- a/hypervisor/manager/vm.go
+++ b/hypervisor/manager/vm.go
@@ -101,7 +101,7 @@ func computeSize(minimumFreeBytes, roundupPower, size uint64) uint64 {
 // copyData will create and truncate the specified file and will copy data to
 // the file. If reader is nil, the file is fallocated or zero-filled.
 func copyData(filename string, reader io.Reader, length uint64,
-	logger log.DebugLogger) error {
+	disableFillZero bool, logger log.DebugLogger) error {
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY,
 		fsutil.PrivateFilePerms)
 	if err != nil {
@@ -112,7 +112,7 @@ func copyData(filename string, reader io.Reader, length uint64,
 		return err
 	}
 	if reader == nil {
-		return fsutil.FallocateOrFill(filename, length, logger)
+		return fsutil.FallocateOrFill(filename, length, disableFillZero, logger)
 	}
 	_, err = io.CopyN(file, reader, int64(length))
 	return err
@@ -1341,6 +1341,7 @@ func (m *Manager) createVm(conn *srpc.Conn) error {
 			return err
 		}
 		writeRawOptions := util.WriteRawOptions{
+			DisableFillZero:    m.DisableFillZero,
 			ExtraKernelOptions: request.ExtraKernelOptions,
 			InitialImageName:   imageName,
 			MinimumFreeBytes:   request.MinimumFreeBytes,
@@ -1401,7 +1402,7 @@ func (m *Manager) createVm(conn *srpc.Conn) error {
 	vm.Volumes[0].Type = rootVolumeType
 	if request.UserDataSize > 0 {
 		filename := filepath.Join(vm.dirname, UserDataFile)
-		err := copyData(filename, conn, request.UserDataSize, vm.logger)
+		err := copyData(filename, conn, request.UserDataSize, m.DisableFillZero, vm.logger)
 		if err != nil {
 			return sendError(conn, err)
 		}
@@ -1417,7 +1418,7 @@ func (m *Manager) createVm(conn *srpc.Conn) error {
 			if request.SecondaryVolumesData {
 				dataReader = conn
 			}
-			err := copyData(fname, dataReader, volume.Size, vm.logger)
+			err := copyData(fname, dataReader, volume.Size, m.DisableFillZero, vm.logger)
 			if err != nil {
 				return sendError(conn, err)
 			}
@@ -1571,7 +1572,7 @@ func (m *Manager) debugVmImage(conn *srpc.Conn,
 			return sendError(conn, err)
 		}
 	} else if request.ImageDataSize > 0 {
-		err := copyData(rootFilename, conn, request.ImageDataSize, vm.logger)
+		err := copyData(rootFilename, conn, request.ImageDataSize, m.DisableFillZero, vm.logger)
 		if err != nil {
 			return sendError(conn, err)
 		}
@@ -1592,7 +1593,7 @@ func (m *Manager) debugVmImage(conn *srpc.Conn,
 				errors.New("ContentLength from: "+request.ImageURL))
 		}
 		err = copyData(rootFilename, httpResponse.Body,
-			uint64(httpResponse.ContentLength), vm.logger)
+			uint64(httpResponse.ContentLength), m.DisableFillZero, vm.logger)
 		if err != nil {
 			return sendError(conn, err)
 		}
@@ -3219,7 +3220,7 @@ func (m *Manager) replaceVmImage(conn *srpc.Conn,
 			newSize = uint64(fi.Size())
 		}
 	} else if request.ImageDataSize > 0 {
-		err := copyData(tmpRootFilename, conn, request.ImageDataSize, vm.logger)
+		err := copyData(tmpRootFilename, conn, request.ImageDataSize, m.DisableFillZero, vm.logger)
 		if err != nil {
 			return err
 		}
@@ -3245,7 +3246,7 @@ func (m *Manager) replaceVmImage(conn *srpc.Conn,
 				errors.New("ContentLength from: "+request.ImageURL))
 		}
 		err = copyData(tmpRootFilename, httpResponse.Body,
-			uint64(httpResponse.ContentLength), vm.logger)
+			uint64(httpResponse.ContentLength), m.DisableFillZero, vm.logger)
 		if err != nil {
 			return sendError(conn, err)
 		}
@@ -3894,7 +3895,7 @@ func (vm *vmInfoType) copyRootVolume(request proto.CreateVmRequest,
 	if err != nil {
 		return err
 	}
-	err = copyData(vm.VolumeLocations[0].Filename, reader, dataSize, vm.logger)
+	err = copyData(vm.VolumeLocations[0].Filename, reader, dataSize, false, vm.logger)
 	if err != nil {
 		return err
 	}

--- a/lib/filesystem/util/api.go
+++ b/lib/filesystem/util/api.go
@@ -148,6 +148,7 @@ func WriteImageName(mountPoint, imageName string) error {
 type WriteRawOptions struct {
 	AllocateBlocks       bool
 	DoChroot             bool
+	DisableFillZero      bool
 	ExtraKernelOptions   string
 	InitialImageName     string
 	InstallBootloader    bool

--- a/lib/filesystem/util/writeRaw.go
+++ b/lib/filesystem/util/writeRaw.go
@@ -682,7 +682,7 @@ func writeToFile(fs *filesystem.FileSystem,
 		return err
 	}
 	if options.AllocateBlocks {
-		err := fsutil.FallocateOrFill(tmpFilename, imageSize, logger)
+		err := fsutil.FallocateOrFill(tmpFilename, imageSize, options.DisableFillZero, logger)
 		if err != nil {
 			return fmt.Errorf("error fallocating file: %s: %s",
 				tmpFilename, err)

--- a/lib/fsutil/api.go
+++ b/lib/fsutil/api.go
@@ -103,8 +103,8 @@ func Fallocate(filename string, size uint64) error {
 // specified in bytes. If allocation is not supported/available, the file will
 // be filled with zeros (and a debug message will be logged).
 func FallocateOrFill(filename string, size uint64,
-	logger log.DebugLogger) error {
-	return fallocateOrFill(filename, size, logger)
+	disableFillZero bool, logger log.DebugLogger) error {
+	return fallocateOrFill(filename, size, disableFillZero, logger)
 }
 
 // ForceLink creates newname as a hard link to the oldname file. It first

--- a/lib/fsutil/fallocate.go
+++ b/lib/fsutil/fallocate.go
@@ -27,7 +27,7 @@ func fallocate(filename string, size uint64) error {
 }
 
 func fallocateOrFill(filename string, size uint64,
-	logger log.DebugLogger) error {
+	disableFillZero bool, logger log.DebugLogger) error {
 	err := Fallocate(filename, size)
 	if err == nil {
 		return nil
@@ -42,6 +42,11 @@ func fallocateOrFill(filename string, size uint64,
 	}
 	if !errors.Is(err, syscall.ENOTSUP) {
 		return err
+	}
+	// File allocation is not supported and disableFillZero is set, then skip operation.
+	if disableFillZero {
+		logger.Printf("unable to fallocate, disableFillZero flag set, skipping operation")
+		return nil
 	}
 	// File allocation is not supported, and file isn't big enough. Fill it.
 	logger.Printf("unable to fallocate, writing zeros to: %s\n", filename)


### PR DESCRIPTION
Allow VMs to be created without writing zeroes to file if fallocate operation is not available.