### PR TITLE
implement files.append and post-install-files.append in image manifests

### DIFF
--- a/imagebuilder/builder/processManifest.go
+++ b/imagebuilder/builder/processManifest.go
@@ -229,6 +229,9 @@ func processManifest(ctx context.Context, manifestDir, rootDir string,
 	if err != nil {
 		return fmt.Errorf("error copying in /etc/resolv.conf: %s", err)
 	}
+	if err := appendFiles(manifestDir, "files.append", rootDir, buildLog); err != nil {
+		return err
+	}
 	if err := copyFiles(manifestDir, "files", rootDir, buildLog); err != nil {
 		return err
 	}
@@ -258,6 +261,9 @@ func processManifest(ctx context.Context, manifestDir, rootDir string,
 	if err != nil {
 		return err
 	}
+	if err := appendFiles(manifestDir, "post-install-files.append", rootDir, buildLog); err != nil {
+		return err
+	}
 	err = runScripts(ctx, g, manifestDir, "scripts", rootDir, envGetter,
 		buildLog)
 	if err != nil {
@@ -282,6 +288,29 @@ func processManifest(ctx context.Context, manifestDir, rootDir string,
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func appendFiles(manifestDir, dirname, rootDir string, buildLog io.Writer) error {
+	startTime := time.Now()
+	sourceDir := filepath.Join(manifestDir, dirname)
+	_, err := os.Open(sourceDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(buildLog, "No %s directory\n", dirname)
+			return nil
+		}
+		return err
+	}
+
+	cf := func(destFilename, sourceFilename string, mode os.FileMode) error {
+		return fsutil.AppendFile(destFilename, sourceFilename, mode)
+	}
+	// Supporting append only for regular files
+	if err := fsutil.CopyFilesTreeWithCopyFunc(rootDir, sourceDir, cf); err != nil {
+		return fmt.Errorf("error appending %s: %s", dirname, err)
+	}
+	fmt.Fprintf(buildLog, "\nAppended %s tree in %s\n", dirname, format.Duration(time.Since(startTime)))
 	return nil
 }
 

--- a/imagebuilder/builder/processManifest.go
+++ b/imagebuilder/builder/processManifest.go
@@ -229,10 +229,10 @@ func processManifest(ctx context.Context, manifestDir, rootDir string,
 	if err != nil {
 		return fmt.Errorf("error copying in /etc/resolv.conf: %s", err)
 	}
-	if err := appendFiles(manifestDir, "files.append", rootDir, buildLog); err != nil {
+	if err := copyFiles(manifestDir, "files", rootDir, buildLog); err != nil {
 		return err
 	}
-	if err := copyFiles(manifestDir, "files", rootDir, buildLog); err != nil {
+	if err := appendFiles(manifestDir, "files.append", rootDir, buildLog); err != nil {
 		return err
 	}
 	err = runScripts(ctx, g, manifestDir, "pre-install-scripts", rootDir,

--- a/imagebuilder/builder/processManifest.go
+++ b/imagebuilder/builder/processManifest.go
@@ -232,7 +232,8 @@ func processManifest(ctx context.Context, manifestDir, rootDir string,
 	if err := copyFiles(manifestDir, "files", rootDir, buildLog); err != nil {
 		return err
 	}
-	if err := appendFiles(manifestDir, "files.append", rootDir, buildLog); err != nil {
+	err = appendFiles(manifestDir, "files.append", rootDir, buildLog)
+	if err != nil {
 		return err
 	}
 	err = runScripts(ctx, g, manifestDir, "pre-install-scripts", rootDir,
@@ -261,7 +262,9 @@ func processManifest(ctx context.Context, manifestDir, rootDir string,
 	if err != nil {
 		return err
 	}
-	if err := appendFiles(manifestDir, "post-install-files.append", rootDir, buildLog); err != nil {
+	err = appendFiles(manifestDir, "post-install-files.append",
+		rootDir, buildLog)
+	if err != nil {
 		return err
 	}
 	err = runScripts(ctx, g, manifestDir, "scripts", rootDir, envGetter,
@@ -306,7 +309,7 @@ func appendFiles(manifestDir, dirname, rootDir string, buildLog io.Writer) error
 	cf := func(destFilename, sourceFilename string, mode os.FileMode) error {
 		return fsutil.AppendFile(destFilename, sourceFilename, mode)
 	}
-	// Supporting append only for regular files
+	// Supporting append only for regular files.
 	if err := fsutil.CopyFilesTreeWithCopyFunc(rootDir, sourceDir, cf); err != nil {
 		return fmt.Errorf("error appending %s: %s", dirname, err)
 	}

--- a/imagebuilder/builder/processManifest.go
+++ b/imagebuilder/builder/processManifest.go
@@ -305,12 +305,7 @@ func appendFiles(manifestDir, dirname, rootDir string, buildLog io.Writer) error
 		}
 		return err
 	}
-
-	cf := func(destFilename, sourceFilename string, mode os.FileMode) error {
-		return fsutil.AppendFile(destFilename, sourceFilename, mode)
-	}
-	// Supporting append only for regular files.
-	if err := fsutil.CopyFilesTreeWithCopyFunc(rootDir, sourceDir, cf); err != nil {
+	if err := fsutil.AppendTree(rootDir, sourceDir); err != nil {
 		return fmt.Errorf("error appending %s: %s", dirname, err)
 	}
 	fmt.Fprintf(buildLog, "\nAppended %s tree in %s\n", dirname, format.Duration(time.Since(startTime)))

--- a/lib/fsutil/api.go
+++ b/lib/fsutil/api.go
@@ -23,13 +23,13 @@ var (
 	ErrorChecksumMismatch = errors.New("checksum mismatch")
 )
 
-// AppemdFile will append data from the sourceFilename to destFilename.
+// AppendFile will append data from the sourceFilename to destFilename.
 // If destFilename does not exist, it is created with permissions
 // copied from sourceFilename. If there are any errors, then destFilename
 // may have partial data appended.
 // AppendFile is not safe to call concurrently for the same file.
 func AppendFile(destFilename, sourceFilename string, mode os.FileMode) error {
-	return appendFile(destFilename, sourceFilename, mode, false)
+	return appendFile(destFilename, sourceFilename, mode)
 }
 
 // CompareFile will read and compare the content of a file and buffer and will
@@ -94,8 +94,8 @@ func CopyFilesTree(destDir, sourceDir string) error {
 	return copyTree(destDir, sourceDir, false, CopyFile)
 }
 
-// CopyFilesTreeWithCopyFunc is similar to CopyFilesTree except it uses a specified copy
-// function for copying regular files.
+// CopyFilesTreeWithCopyFunc is similar to CopyFilesTree
+// except it uses a specified copy function for copying regular files.
 func CopyFilesTreeWithCopyFunc(destDir, souceDir string,
 	copyFunc func(destFilename, sourceFilename string,
 		mode os.FileMode) error) error {

--- a/lib/fsutil/api.go
+++ b/lib/fsutil/api.go
@@ -23,6 +23,15 @@ var (
 	ErrorChecksumMismatch = errors.New("checksum mismatch")
 )
 
+// AppemdFile will append data from the sourceFilename to destFilename.
+// If destFilename does not exist, it is created with permissions
+// copied from sourceFilename. If there are any errors, then destFilename
+// may have partial data appended.
+// AppendFile is not safe to call concurrently for the same file.
+func AppendFile(destFilename, sourceFilename string, mode os.FileMode) error {
+	return appendFile(destFilename, sourceFilename, mode, false)
+}
+
 // CompareFile will read and compare the content of a file and buffer and will
 // return true if the contents are the same else false.
 func CompareFile(buffer []byte, filename string) (bool, error) {
@@ -83,6 +92,14 @@ func CopyTree(destDir, sourceDir string) error {
 // are ignored.
 func CopyFilesTree(destDir, sourceDir string) error {
 	return copyTree(destDir, sourceDir, false, CopyFile)
+}
+
+// CopyFilesTreeWithCopyFunc is similar to CopyFilesTree except it uses a specified copy
+// function for copying regular files.
+func CopyFilesTreeWithCopyFunc(destDir, souceDir string,
+	copyFunc func(destFilename, sourceFilename string,
+		mode os.FileMode) error) error {
+	return copyTree(destDir, souceDir, false, copyFunc)
 }
 
 // CopyTreeWithCopyFunc is similar to CopyTree except it uses a specified copy

--- a/lib/fsutil/api.go
+++ b/lib/fsutil/api.go
@@ -28,8 +28,17 @@ var (
 // copied from sourceFilename. If there are any errors, then destFilename
 // may have partial data appended.
 // AppendFile is not safe to call concurrently for the same file.
-func AppendFile(destFilename, sourceFilename string, mode os.FileMode) error {
-	return appendFile(destFilename, sourceFilename, mode)
+func AppendFile(destFilename, sourceFilename string) error {
+	return appendFile(destFilename, sourceFilename)
+}
+
+// AppendTree recursively merges sourceDir into destDir.
+// It appends contents to existing files or copies new ones
+// while preserving permissions.
+// Directory structures are mirrored.
+// Returns an error if symlinks or non-regular files are encountered.
+func AppendTree(destDir, sourceDir string) error {
+	return appendTree(destDir, sourceDir, AppendFile)
 }
 
 // CompareFile will read and compare the content of a file and buffer and will
@@ -92,14 +101,6 @@ func CopyTree(destDir, sourceDir string) error {
 // are ignored.
 func CopyFilesTree(destDir, sourceDir string) error {
 	return copyTree(destDir, sourceDir, false, CopyFile)
-}
-
-// CopyFilesTreeWithCopyFunc is similar to CopyFilesTree
-// except it uses a specified copy function for copying regular files.
-func CopyFilesTreeWithCopyFunc(destDir, souceDir string,
-	copyFunc func(destFilename, sourceFilename string,
-		mode os.FileMode) error) error {
-	return copyTree(destDir, souceDir, false, copyFunc)
 }
 
 // CopyTreeWithCopyFunc is similar to CopyTree except it uses a specified copy

--- a/lib/fsutil/append.go
+++ b/lib/fsutil/append.go
@@ -62,7 +62,6 @@ func appendTree(destDir, sourceDir string,
 				return err
 			}
 			destFilename := filepath.Join(destDir, relPath)
-
 			fileType := d.Type()
 			switch {
 			case fileType.IsDir():

--- a/lib/fsutil/append.go
+++ b/lib/fsutil/append.go
@@ -57,7 +57,6 @@ func appendTree(destDir, sourceDir string,
 			if err != nil {
 				return err
 			}
-
 			relPath, err := filepath.Rel(sourceDir, path)
 			if err != nil {
 				return err
@@ -72,19 +71,15 @@ func appendTree(destDir, sourceDir string,
 				if err := os.MkdirAll(destFilename, DirPerms); err != nil {
 					return err
 				}
-
 			case fileType.IsRegular():
 				if err := appendFunc(destFilename, path); err != nil {
 					return err
 				}
-
 			case fileType&fs.ModeSymlink != 0:
 				return errors.New("symlinks are not supported")
-
 			default:
 				return fmt.Errorf("unsupported file type: %s", fileType.String())
 			}
-
 			return nil
 		})
 }

--- a/lib/fsutil/append.go
+++ b/lib/fsutil/append.go
@@ -1,0 +1,42 @@
+package fsutil
+
+import (
+	"errors"
+	"io"
+	"os"
+)
+
+func appendToFile(destFilename string, reader io.Reader, length uint64) error {
+	destFile, err := os.OpenFile(destFilename, os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+	if err := copyToWriter(destFile, destFilename, reader, length); err != nil {
+		return err
+	}
+	return destFile.Close()
+}
+
+func appendFile(destFilename, sourceFilename string, mode os.FileMode, exclusive bool) error {
+	if _, err := os.Stat(destFilename); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Dest file doesn't exist, so just copy the file
+			if mode == 0 {
+				var err error
+				mode, err = getFilePerms(sourceFilename)
+				if err != nil {
+					return err
+				}
+			}
+			return copyFile(destFilename, sourceFilename, mode, exclusive)
+		}
+	}
+	sourceFile, err := os.Open(sourceFilename)
+	if err != nil {
+		return errors.New(sourceFilename + ": " + err.Error())
+	}
+	defer sourceFile.Close()
+	// Dest file exists, so append to it
+	return appendToFile(destFilename, sourceFile, 0)
+}

--- a/lib/fsutil/append.go
+++ b/lib/fsutil/append.go
@@ -18,10 +18,10 @@ func appendToFile(destFilename string, reader io.Reader, length uint64) error {
 	return destFile.Close()
 }
 
-func appendFile(destFilename, sourceFilename string, mode os.FileMode, exclusive bool) error {
+func appendFile(destFilename, sourceFilename string, mode os.FileMode) error {
 	if _, err := os.Stat(destFilename); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			// Dest file doesn't exist, so just copy the file
+			// Dest file doesn't exist, so just copy the file.
 			if mode == 0 {
 				var err error
 				mode, err = getFilePerms(sourceFilename)
@@ -29,7 +29,7 @@ func appendFile(destFilename, sourceFilename string, mode os.FileMode, exclusive
 					return err
 				}
 			}
-			return copyFile(destFilename, sourceFilename, mode, exclusive)
+			return copyFile(destFilename, sourceFilename, mode, false)
 		}
 	}
 	sourceFile, err := os.Open(sourceFilename)
@@ -37,6 +37,6 @@ func appendFile(destFilename, sourceFilename string, mode os.FileMode, exclusive
 		return errors.New(sourceFilename + ": " + err.Error())
 	}
 	defer sourceFile.Close()
-	// Dest file exists, so append to it
+	// Dest file exists, so append to it.
 	return appendToFile(destFilename, sourceFile, 0)
 }

--- a/lib/fsutil/append.go
+++ b/lib/fsutil/append.go
@@ -2,8 +2,11 @@ package fsutil
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
 )
 
 func appendToFile(destFilename string, reader io.Reader,
@@ -26,16 +29,14 @@ func appendToFile(destFilename string, reader io.Reader,
 	return nil
 }
 
-func appendFile(destFilename, sourceFilename string, mode os.FileMode) error {
+func appendFile(destFilename, sourceFilename string) error {
 	if _, err := os.Stat(destFilename); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			// Dest file doesn't exist, so just copy the file.
-			if mode == 0 {
-				var err error
-				mode, err = getFilePerms(sourceFilename)
-				if err != nil {
-					return err
-				}
+			var err error
+			mode, err := getFilePerms(sourceFilename)
+			if err != nil {
+				return err
 			}
 			return copyFile(destFilename, sourceFilename, mode, false)
 		}
@@ -47,4 +48,43 @@ func appendFile(destFilename, sourceFilename string, mode os.FileMode) error {
 	defer sourceFile.Close()
 	// Dest file exists, so append to it.
 	return appendToFile(destFilename, sourceFile, 0)
+}
+
+func appendTree(destDir, sourceDir string,
+	appendFunc func(dest, src string) error) error {
+	return filepath.WalkDir(sourceDir,
+		func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			relPath, err := filepath.Rel(sourceDir, path)
+			if err != nil {
+				return err
+			}
+			destFilename := filepath.Join(destDir, relPath)
+
+			fileType := d.Type()
+			switch {
+			case fileType.IsDir():
+				// If path is a directory, create directory and return.
+				// WalkDir will automatically visit the children next.
+				if err := os.MkdirAll(destFilename, DirPerms); err != nil {
+					return err
+				}
+
+			case fileType.IsRegular():
+				if err := appendFunc(destFilename, path); err != nil {
+					return err
+				}
+
+			case fileType&fs.ModeSymlink != 0:
+				return errors.New("symlinks are not supported")
+
+			default:
+				return fmt.Errorf("unsupported file type: %s", fileType.String())
+			}
+
+			return nil
+		})
 }

--- a/lib/fsutil/append.go
+++ b/lib/fsutil/append.go
@@ -6,16 +6,24 @@ import (
 	"os"
 )
 
-func appendToFile(destFilename string, reader io.Reader, length uint64) error {
+func appendToFile(destFilename string, reader io.Reader,
+	length uint64) (err error) {
 	destFile, err := os.OpenFile(destFilename, os.O_WRONLY|os.O_APPEND, 0)
 	if err != nil {
 		return err
 	}
-	defer destFile.Close()
+	defer func() {
+		closeError := destFile.Close()
+		// If our function succeeded, but the close failed,
+		// return the close error instead.
+		if err == nil && closeError != nil {
+			err = closeError
+		}
+	}()
 	if err := copyToWriter(destFile, destFilename, reader, length); err != nil {
 		return err
 	}
-	return destFile.Close()
+	return nil
 }
 
 func appendFile(destFilename, sourceFilename string, mode os.FileMode) error {

--- a/lib/fsutil/append_test.go
+++ b/lib/fsutil/append_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAppendFileNonExistingDestFile(t *testing.T) {
-	// setup source file
+	// setup source file.
 	tmp := t.TempDir()
 
 	const (
@@ -18,20 +18,24 @@ func TestAppendFileNonExistingDestFile(t *testing.T) {
 		destFileName   = "dest"
 	)
 	var (
-		sourceFileData                   = []byte("#/usr/bin/bash\nVAR1=$(which bash)\necho $VAR1\nthis is \n\ttest data\n")
+		sourceFileData = []byte(
+			"#/usr/bin/bash\nVAR1=$(which bash)\necho $VAR1\nthis is \n\ttest data\n",
+		)
 		expectedDestFileData             = sourceFileData
 		filePerms            os.FileMode = 0600
 	)
 	sourceFilePath := filepath.Join(tmp, sourceFileName)
 	destFilePath := filepath.Join(tmp, destFileName)
-	// create source file with data
-	if err := copyToFile(sourceFilePath, 0600, bytes.NewReader(sourceFileData), 0); err != nil {
+	// create source file with data.
+	if err := copyToFile(sourceFilePath, 0600,
+		bytes.NewReader(sourceFileData), 0); err != nil {
 		t.Fatalf("error creating source file %s: %s\n", sourceFilePath, err.Error())
 	}
-	// skipping creation of dest file path
+	// skipping creation of dest file path.
 
-	// check dest file doesn't exist before append
-	if _, err := os.Stat(destFilePath); err == nil || !errors.Is(err, os.ErrNotExist) {
+	// check dest file doesn't exist before append.
+	_, err := os.Stat(destFilePath)
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
 		t.Fatal("destfile exists already\n")
 	}
 	if err := AppendFile(destFilePath, sourceFilePath, 0); err != nil {
@@ -41,15 +45,19 @@ func TestAppendFileNonExistingDestFile(t *testing.T) {
 	d, _ := io.ReadAll(f)
 	t.Logf("file content is \n%s\n", string(d))
 
-	// check file perm of dest, it should be same as source
+	// check file perm of dest, it should be same as source.
 	mode, err := getFilePerms(destFilePath)
 	if err != nil {
 		t.Fatalf("error getting dest file perms %s\n", err.Error())
 	}
 	if mode != filePerms {
-		t.Fatalf("dest file perms are not as expected, current: %d, expected: %d\n", mode, filePerms)
+		t.Fatalf(
+			"dest file perms are not as expected, current: %d, expected: %d\n",
+			mode,
+			filePerms,
+		)
 	}
-	// dest file should exist
+	// dest file should exist.
 	same, err := CompareFile(expectedDestFileData, destFilePath)
 	if err != nil {
 		t.Fatalf("error appending to file: %s\n", err.Error())
@@ -60,7 +68,7 @@ func TestAppendFileNonExistingDestFile(t *testing.T) {
 }
 
 func TestAppendFileWithExistingDestFile(t *testing.T) {
-	// setup source file
+	// setup source file.
 	tmp := t.TempDir()
 
 	const (
@@ -68,18 +76,30 @@ func TestAppendFileWithExistingDestFile(t *testing.T) {
 		destFileName   = "dest"
 	)
 	var (
-		sourceFileData       = []byte("#/usr/bin/bash\nVAR1=$(which bash)\necho $VAR1\nthis is \n\ttest data\n")
+		sourceFileData = []byte(
+			"#/usr/bin/bash\nVAR1=$(which bash)\necho $VAR1\nthis is \n\ttest data\n",
+		)
 		destFileData         = []byte("#/usr/bin/python\necho 'this is test data'\n")
 		expectedDestFileData = append(destFileData, sourceFileData...)
 	)
 	sourceFilePath := filepath.Join(tmp, sourceFileName)
 	destFilePath := filepath.Join(tmp, destFileName)
-	// create source file with data
-	if err := copyToFile(sourceFilePath, PublicFilePerms, bytes.NewReader(sourceFileData), 0); err != nil {
+	// create source file with data.
+	if err := copyToFile(
+		sourceFilePath,
+		PublicFilePerms,
+		bytes.NewReader(sourceFileData),
+		0,
+	); err != nil {
 		t.Fatalf("error creating source file %s: %s\n", sourceFilePath, err.Error())
 	}
-	// create dest file with data
-	if err := copyToFile(destFilePath, PublicFilePerms, bytes.NewReader(destFileData), 0); err != nil {
+	// create dest file with data.
+	if err := copyToFile(
+		destFilePath,
+		PublicFilePerms,
+		bytes.NewReader(destFileData),
+		0,
+	); err != nil {
 		t.Fatalf("error creating dest file %s: %s\n", destFilePath, err.Error())
 	}
 
@@ -90,7 +110,7 @@ func TestAppendFileWithExistingDestFile(t *testing.T) {
 	d, _ := io.ReadAll(f)
 	t.Logf("file content is \n%s\n", string(d))
 
-	// dest file should exist
+	// dest file should exist.
 	same, err := CompareFile(expectedDestFileData, destFilePath)
 	if err != nil {
 		t.Fatalf("error appending to file: %s\n", err.Error())

--- a/lib/fsutil/append_test.go
+++ b/lib/fsutil/append_test.go
@@ -1,0 +1,101 @@
+package fsutil
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAppendFileNonExistingDestFile(t *testing.T) {
+	// setup source file
+	tmp := t.TempDir()
+
+	const (
+		sourceFileName = "source"
+		destFileName   = "dest"
+	)
+	var (
+		sourceFileData                   = []byte("#/usr/bin/bash\nVAR1=$(which bash)\necho $VAR1\nthis is \n\ttest data\n")
+		expectedDestFileData             = sourceFileData
+		filePerms            os.FileMode = 0600
+	)
+	sourceFilePath := filepath.Join(tmp, sourceFileName)
+	destFilePath := filepath.Join(tmp, destFileName)
+	// create source file with data
+	if err := copyToFile(sourceFilePath, 0600, bytes.NewReader(sourceFileData), 0); err != nil {
+		t.Fatalf("error creating source file %s: %s\n", sourceFilePath, err.Error())
+	}
+	// skipping creation of dest file path
+
+	// check dest file doesn't exist before append
+	if _, err := os.Stat(destFilePath); err == nil || !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("destfile exists already\n")
+	}
+	if err := AppendFile(destFilePath, sourceFilePath, 0); err != nil {
+		t.Fatalf("error appending to file: %s\n", err.Error())
+	}
+	f, _ := os.OpenFile(destFilePath, os.O_RDONLY, 0)
+	d, _ := io.ReadAll(f)
+	t.Logf("file content is \n%s\n", string(d))
+
+	// check file perm of dest, it should be same as source
+	mode, err := getFilePerms(destFilePath)
+	if err != nil {
+		t.Fatalf("error getting dest file perms %s\n", err.Error())
+	}
+	if mode != filePerms {
+		t.Fatalf("dest file perms are not as expected, current: %d, expected: %d\n", mode, filePerms)
+	}
+	// dest file should exist
+	same, err := CompareFile(expectedDestFileData, destFilePath)
+	if err != nil {
+		t.Fatalf("error appending to file: %s\n", err.Error())
+	}
+	if !same {
+		t.Fatalf("contents mismatch after append")
+	}
+}
+
+func TestAppendFileWithExistingDestFile(t *testing.T) {
+	// setup source file
+	tmp := t.TempDir()
+
+	const (
+		sourceFileName = "source"
+		destFileName   = "dest"
+	)
+	var (
+		sourceFileData       = []byte("#/usr/bin/bash\nVAR1=$(which bash)\necho $VAR1\nthis is \n\ttest data\n")
+		destFileData         = []byte("#/usr/bin/python\necho 'this is test data'\n")
+		expectedDestFileData = append(destFileData, sourceFileData...)
+	)
+	sourceFilePath := filepath.Join(tmp, sourceFileName)
+	destFilePath := filepath.Join(tmp, destFileName)
+	// create source file with data
+	if err := copyToFile(sourceFilePath, PublicFilePerms, bytes.NewReader(sourceFileData), 0); err != nil {
+		t.Fatalf("error creating source file %s: %s\n", sourceFilePath, err.Error())
+	}
+	// create dest file with data
+	if err := copyToFile(destFilePath, PublicFilePerms, bytes.NewReader(destFileData), 0); err != nil {
+		t.Fatalf("error creating dest file %s: %s\n", destFilePath, err.Error())
+	}
+
+	if err := AppendFile(destFilePath, sourceFilePath, 0); err != nil {
+		t.Fatalf("error appending to file: %s\n", err.Error())
+	}
+	f, _ := os.OpenFile(destFilePath, os.O_RDONLY, 0)
+	d, _ := io.ReadAll(f)
+	t.Logf("file content is \n%s\n", string(d))
+
+	// dest file should exist
+	same, err := CompareFile(expectedDestFileData, destFilePath)
+	if err != nil {
+		t.Fatalf("error appending to file: %s\n", err.Error())
+	}
+	if !same {
+		t.Fatalf("contents mismatch after append")
+	}
+}

--- a/lib/fsutil/append_test.go
+++ b/lib/fsutil/append_test.go
@@ -9,14 +9,15 @@ import (
 	"testing"
 )
 
+const (
+	sourceFileName = "source"
+	destFileName   = "dest"
+)
+
 func TestAppendFileNonExistingDestFile(t *testing.T) {
 	// setup source file.
 	tmp := t.TempDir()
 
-	const (
-		sourceFileName = "source"
-		destFileName   = "dest"
-	)
 	var (
 		sourceFileData = []byte(
 			"#/usr/bin/bash\nVAR1=$(which bash)\necho $VAR1\nthis is \n\ttest data\n",
@@ -70,11 +71,6 @@ func TestAppendFileNonExistingDestFile(t *testing.T) {
 func TestAppendFileWithExistingDestFile(t *testing.T) {
 	// setup source file.
 	tmp := t.TempDir()
-
-	const (
-		sourceFileName = "source"
-		destFileName   = "dest"
-	)
 	var (
 		sourceFileData = []byte(
 			"#/usr/bin/bash\nVAR1=$(which bash)\necho $VAR1\nthis is \n\ttest data\n",

--- a/lib/fsutil/append_test.go
+++ b/lib/fsutil/append_test.go
@@ -9,12 +9,33 @@ import (
 	"testing"
 )
 
-const (
-	sourceFileName = "source"
-	destFileName   = "dest"
-)
+func createBaseDirectory(t *testing.T, path string, perms os.FileMode) {
+	// Mark this function as Helper.
+	t.Helper()
+
+	dir := filepath.Dir(path)
+	info, err := os.Stat(dir)
+	if err == nil {
+		if !info.IsDir() {
+			t.Fatalf("path exists but is a file: %s", dir)
+		}
+	}
+
+	if !os.IsNotExist(err) {
+		t.Fatal(err.Error())
+	}
+
+	err = os.MkdirAll(dir, perms)
+	if err != nil {
+		t.Fatalf("error creating directory dir %s: %s", dir, err.Error())
+	}
+}
 
 func TestAppendFileNonExistingDestFile(t *testing.T) {
+	const (
+		sourceFileName = "dir1/source"
+		destFileName   = "dir2/dir3/dest"
+	)
 	// setup source file.
 	tmp := t.TempDir()
 
@@ -27,6 +48,7 @@ func TestAppendFileNonExistingDestFile(t *testing.T) {
 	)
 	sourceFilePath := filepath.Join(tmp, sourceFileName)
 	destFilePath := filepath.Join(tmp, destFileName)
+	createBaseDirectory(t, sourceFilePath, 0755)
 	// create source file with data.
 	if err := copyToFile(sourceFilePath, 0600,
 		bytes.NewReader(sourceFileData), 0); err != nil {
@@ -39,15 +61,19 @@ func TestAppendFileNonExistingDestFile(t *testing.T) {
 	if err == nil || !errors.Is(err, os.ErrNotExist) {
 		t.Fatal("destfile exists already\n")
 	}
-	if err := AppendFile(destFilePath, sourceFilePath, 0); err != nil {
+	if err := AppendTree(filepath.Dir(destFilePath),
+		filepath.Dir(sourceFilePath)); err != nil {
 		t.Fatalf("error appending to file: %s\n", err.Error())
 	}
-	f, _ := os.OpenFile(destFilePath, os.O_RDONLY, 0)
+	// Since Destination file is not present, the entire Tree will be
+	// created with source file.
+	finalDestPath := filepath.Join(tmp, "dir2/dir3/source")
+	f, _ := os.OpenFile(finalDestPath, os.O_RDONLY, 0)
 	d, _ := io.ReadAll(f)
 	t.Logf("file content is \n%s\n", string(d))
 
 	// check file perm of dest, it should be same as source.
-	mode, err := getFilePerms(destFilePath)
+	mode, err := getFilePerms(finalDestPath)
 	if err != nil {
 		t.Fatalf("error getting dest file perms %s\n", err.Error())
 	}
@@ -59,7 +85,7 @@ func TestAppendFileNonExistingDestFile(t *testing.T) {
 		)
 	}
 	// dest file should exist.
-	same, err := CompareFile(expectedDestFileData, destFilePath)
+	same, err := CompareFile(expectedDestFileData, finalDestPath)
 	if err != nil {
 		t.Fatalf("error appending to file: %s\n", err.Error())
 	}
@@ -70,6 +96,10 @@ func TestAppendFileNonExistingDestFile(t *testing.T) {
 
 func TestAppendFileWithExistingDestFile(t *testing.T) {
 	// setup source file.
+	const (
+		sourceFileName = "dir1/dir2/dir3/source"
+		destFileName   = "dir4/dir2/dir3/dest"
+	)
 	tmp := t.TempDir()
 	var (
 		sourceFileData = []byte(
@@ -80,6 +110,8 @@ func TestAppendFileWithExistingDestFile(t *testing.T) {
 	)
 	sourceFilePath := filepath.Join(tmp, sourceFileName)
 	destFilePath := filepath.Join(tmp, destFileName)
+	createBaseDirectory(t, sourceFilePath, 0755)
+	createBaseDirectory(t, destFilePath, 0755)
 	// create source file with data.
 	if err := copyToFile(
 		sourceFilePath,
@@ -99,7 +131,7 @@ func TestAppendFileWithExistingDestFile(t *testing.T) {
 		t.Fatalf("error creating dest file %s: %s\n", destFilePath, err.Error())
 	}
 
-	if err := AppendFile(destFilePath, sourceFilePath, 0); err != nil {
+	if err := AppendFile(destFilePath, sourceFilePath); err != nil {
 		t.Fatalf("error appending to file: %s\n", err.Error())
 	}
 	f, _ := os.OpenFile(destFilePath, os.O_RDONLY, 0)

--- a/lib/fsutil/append_test.go
+++ b/lib/fsutil/append_test.go
@@ -12,7 +12,6 @@ import (
 func createBaseDirectory(t *testing.T, path string, perms os.FileMode) {
 	// Mark this function as Helper.
 	t.Helper()
-
 	dir := filepath.Dir(path)
 	info, err := os.Stat(dir)
 	if err == nil {
@@ -20,11 +19,9 @@ func createBaseDirectory(t *testing.T, path string, perms os.FileMode) {
 			t.Fatalf("path exists but is a file: %s", dir)
 		}
 	}
-
 	if !os.IsNotExist(err) {
 		t.Fatal(err.Error())
 	}
-
 	err = os.MkdirAll(dir, perms)
 	if err != nil {
 		t.Fatalf("error creating directory dir %s: %s", dir, err.Error())
@@ -38,7 +35,6 @@ func TestAppendFileNonExistingDestFile(t *testing.T) {
 	)
 	// setup source file.
 	tmp := t.TempDir()
-
 	var (
 		sourceFileData = []byte(
 			"#/usr/bin/bash\nVAR1=$(which bash)\necho $VAR1\nthis is \n\ttest data\n",
@@ -55,7 +51,6 @@ func TestAppendFileNonExistingDestFile(t *testing.T) {
 		t.Fatalf("error creating source file %s: %s\n", sourceFilePath, err.Error())
 	}
 	// skipping creation of dest file path.
-
 	// check dest file doesn't exist before append.
 	_, err := os.Stat(destFilePath)
 	if err == nil || !errors.Is(err, os.ErrNotExist) {
@@ -71,7 +66,6 @@ func TestAppendFileNonExistingDestFile(t *testing.T) {
 	f, _ := os.OpenFile(finalDestPath, os.O_RDONLY, 0)
 	d, _ := io.ReadAll(f)
 	t.Logf("file content is \n%s\n", string(d))
-
 	// check file perm of dest, it should be same as source.
 	mode, err := getFilePerms(finalDestPath)
 	if err != nil {
@@ -130,14 +124,12 @@ func TestAppendFileWithExistingDestFile(t *testing.T) {
 	); err != nil {
 		t.Fatalf("error creating dest file %s: %s\n", destFilePath, err.Error())
 	}
-
 	if err := AppendFile(destFilePath, sourceFilePath); err != nil {
 		t.Fatalf("error appending to file: %s\n", err.Error())
 	}
 	f, _ := os.OpenFile(destFilePath, os.O_RDONLY, 0)
 	d, _ := io.ReadAll(f)
 	t.Logf("file content is \n%s\n", string(d))
-
 	// dest file should exist.
 	same, err := CompareFile(expectedDestFileData, destFilePath)
 	if err != nil {

--- a/lib/fsutil/copy.go
+++ b/lib/fsutil/copy.go
@@ -141,11 +141,11 @@ func copyTree(destDir, sourceDir string, allTypes bool,
 func copyFile(destFilename, sourceFilename string, mode os.FileMode,
 	exclusive bool) error {
 	if mode == 0 {
-		var stat wsyscall.Stat_t
-		if err := wsyscall.Stat(sourceFilename, &stat); err != nil {
-			return errors.New(sourceFilename + ": " + err.Error())
+		var err error
+		mode, err = getFilePerms(sourceFilename)
+		if err != nil {
+			return err
 		}
-		mode = os.FileMode(stat.Mode & wsyscall.S_IFMT)
 	}
 	sourceFile, err := os.Open(sourceFilename)
 	if err != nil {

--- a/lib/fsutil/getFilePerms.go
+++ b/lib/fsutil/getFilePerms.go
@@ -1,0 +1,17 @@
+package fsutil
+
+import (
+	"errors"
+	"os"
+
+	"github.com/Cloud-Foundations/Dominator/lib/wsyscall"
+)
+
+func getFilePerms(filename string) (os.FileMode, error) {
+	var stat wsyscall.Stat_t
+	if err := wsyscall.Stat(filename, &stat); err != nil {
+		return 0, errors.New(filename + ": " + err.Error())
+	}
+	mode := os.FileMode(stat.Mode) & os.ModePerm
+	return mode, nil
+}

--- a/user-guide/image-manifest.md
+++ b/user-guide/image-manifest.md
@@ -62,6 +62,15 @@ If present, any files and symbolic links in this directory tree will be
 copied verbatim into the image (prior to installing packages), preserving the
 directory structure.
 
+### `files.append` directory tree
+If present, any files in this directory tree will be appended to their
+corresponding paths in the image, preserving the directory structure.
+If a file already exists in the image, its contents will be appended
+verbatim. If a file does not exist, it will be created with the same
+permissions as the source file, and its contents will be written.
+Symbolic links are not supported in this directory and will be ignored
+if present.
+
 ### `pre-install-scripts` directory
 An optional directory containing scripts to run prior to installing packages.
 These are processed in lexical order. The scripts are run in a contained
@@ -75,6 +84,16 @@ contents of the `files` directory tree should contain any package repositories.
 ### `post-install-files` directory tree
 If present, any files and symbolic links in this directory tree will be
 copied verbatim into the image, preserving the directory structure.
+
+### `post-install-files.append` directory tree
+If present, any files in this directory tree will be appended to their
+corresponding paths in the image, preserving the directory structure.
+If a file already exists in the image, its contents will be appended
+verbatim. If a file does not exist, it will be created with the same
+permissions as the source file, and its contents will be written.
+Symbolic links are not supported in this directory and will be ignored
+if present.
+Unlike post-install-files, this directory performs append operations instead of overwriting.
 
 ### `scripts` directory
 An optional directory containing scripts to run. These are processed in lexical


### PR DESCRIPTION
## Description & Motivation
<!-- 

-->
Implement `files.append` and `post-install-files.append` in imaginator image-manifests
so files are appended verbatim instead of add/replace

Fixes https://github.com/Cloud-Foundations/Dominator/issues/239

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## How Has This Been Tested?
<!-- 
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
-->
- [x] Build a new image with `files.append` and `post-install-files.append` directories , after successful creation of image, create a VM and verify files 
- [X] Unit testing

## Testing Approach
Created files.append and post-files.append directories in a image directory and it's parent with data

Then build the parent image using command
```
builder-tool build-image <dev stream name> <git branch name>
```
Once parent image is built , made sure test files are in place

now build the test image locally with command 
```
builder-tool build-tree-from-manifest <directory of manifest>
```
verified local tree and made sure content is appended verbatim for existing files, and new files are created for non existing files


## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
