### PR TITLE
imagserver: display total size of file-system

### DIFF
--- a/lib/objectserver/filesystem/html.go
+++ b/lib/objectserver/filesystem/html.go
@@ -40,8 +40,9 @@ func (objSrv *ObjectServer) writeHtml(writer io.Writer) {
 			100.0 * float64(unreferencedBytes) / float64(totalBytes)
 	}
 	fmt.Fprintf(writer,
-		"Number of objects: %d, consuming %s (%.1f%% of FS which is %.1f%% full)<br>\n",
-		numObjects, format.FormatBytes(totalBytes), totalUtilisation,
+		"Number of objects: %d, consuming %s (%.1f%% of %s FS which is %.1f%% full)<br>\n",
+		numObjects, format.FormatBytes(totalBytes),
+		totalUtilisation, format.FormatBytes(capacity),
 		utilisation)
 	if numDuplicated > 0 {
 		fmt.Fprintf(writer,


### PR DESCRIPTION
## Description & Motivation
<!-- 

-->
imagserver: display total size of file-system in imageserver html page

Fixes https://github.com/Cloud-Foundations/Dominator/issues/237

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- 
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
-->
- [x] Run service locally and perform necessary validations

## Testing Approach
Build and run dev imageserver locally on a filesystem

setup: create an ext4 filesystem of size 100M , no objects added to imageserver
result: `consuming 0B (0.0% of 84672 KiB FS which is 0.0% full)` 

setup: resize the fs to 200M, still no objects added to imageserver
result: `consuming 0B (0.0% of 174MiB FS which is 0.1% full)`

setup: add 20M object to imageserver using objecttool
result: `consuming 20MiB (11.5% of 174MiB FS which is 11.5% full)` , bar is updated accordingly

<img width="1281" height="480" alt="image" src="https://github.com/user-attachments/assets/d95cbb49-97d3-47fb-b628-b1500f32fa89" />

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works