### PR TITLE
Fix: Commit and Built show unknown in the version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,13 @@ $(BUILD_INFO_FILE): $(BUILD_INFO_DEPS)
 	raw_origin=$$(git remote get-url origin 2>/dev/null || echo unknown); \
 	origin=$$(echo "$$raw_origin" | sed -e 's|^git@[^:]*:||' -e 's|^https://github.com/||' -e 's|\.git$$||'); \
 	branch=$$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown); \
+	commit=$$(git rev-parse --short=8 HEAD 2>/dev/null || echo unknown); \
+	buildtime=$$(git log -1 --format=%cI HEAD 2>/dev/null || echo unknown); \
+	if [ -n "$$(git status --porcelain 2>/dev/null)" ]; then \
+		dirty=true; \
+	else \
+		dirty=false; \
+	fi; \
 	case "$$raw_origin" in *Cloud-Foundations*) is_fork=false;; *) is_fork=true;; esac; \
 	if [ "$$is_fork" = false ] && [ "$$branch" = "master" ]; then \
 		behind=0; \
@@ -84,6 +91,9 @@ $(BUILD_INFO_FILE): $(BUILD_INFO_DEPS)
 	fi; \
 	{ \
 		echo "version=$$version"; \
+		echo "commit=$$commit"; \
+		echo "buildtime=$$buildtime"; \
+		echo "dirty=$$dirty"; \
 		echo "origin=$$origin"; \
 		echo "branch=$$branch"; \
 		echo "behind=$$behind"; \

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,28 @@
 all: generate
-	CGO_ENABLED=0 go install ./cmd/*
+	CGO_ENABLED=0 go install -buildvcs=true ./cmd/*
 	@cd c; make
 	go vet -composites=false ./cmd/*
 
 build-darwin: generate
-	(CGO_ENABLED=0 GOOS=darwin go build ./cmd/*)
+	(CGO_ENABLED=0 GOOS=darwin go build -buildvcs=true ./cmd/*)
 
 build-linux: generate
-	(CGO_ENABLED=0 GOOS=linux go build ./cmd/*)
+	(CGO_ENABLED=0 GOOS=linux go build -buildvcs=true ./cmd/*)
 
 build-windows: generate
-	(CGO_ENABLED=0 GOOS=windows go build ./cmd/*)
+	(CGO_ENABLED=0 GOOS=windows go build -buildvcs=true ./cmd/*)
 
 install-darwin: generate
-	(CGO_ENABLED=0 GOOS=darwin go install ./cmd/*)
+	(CGO_ENABLED=0 GOOS=darwin go install -buildvcs=true ./cmd/*)
 
 install-linux: generate
-	(CGO_ENABLED=0 GOOS=linux go install ./cmd/*)
+	(CGO_ENABLED=0 GOOS=linux go install -buildvcs=true ./cmd/*)
 
 install-linux-arm: generate
-	(CGO_ENABLED=0 GOARCH=arm64 GOOS=linux go install ./cmd/*)
+	(CGO_ENABLED=0 GOARCH=arm64 GOOS=linux go install -buildvcs=true ./cmd/*)
 
 install-windows: generate
-	(CGO_ENABLED=0 GOOS=windows go install ./cmd/*)
+	(CGO_ENABLED=0 GOOS=windows go install -buildvcs=true ./cmd/*)
 
 disruption-manager.tarball: generate
 	@./scripts/make-tarball disruption-manager

--- a/lib/version/impl.go
+++ b/lib/version/impl.go
@@ -3,7 +3,6 @@ package version
 import (
 	_ "embed"
 	"runtime"
-	"runtime/debug"
 	"strconv"
 	"strings"
 )
@@ -11,35 +10,31 @@ import (
 //go:embed BUILD_INFO
 var buildInfoRaw string
 
-type vcsInfo struct {
-	revision  string
+type buildInfo struct {
+	version   string
+	commit    string
 	buildTime string
 	dirty     bool
-}
-
-type buildInfo struct {
-	version string
-	origin  string
-	branch  string
-	behind  int
-	isFork  bool
+	origin    string
+	branch    string
+	behind    int
+	isFork    bool
 }
 
 func get() Info {
-	vcs := getVCSInfo()
 	bi := parseBuildInfo()
 	version := bi.version
-	if vcs.dirty {
+	if bi.dirty {
 		version += "-dirty"
 	}
 	return Info{
 		Version:       version,
-		GitCommit:     vcs.revision,
+		GitCommit:     bi.commit,
 		GitOrigin:     bi.origin,
 		GitBranch:     bi.branch,
 		CommitsBehind: bi.behind,
 		IsFork:        bi.isFork,
-		BuildDate:     vcs.buildTime,
+		BuildDate:     bi.buildTime,
 		GoVersion:     runtime.Version(),
 	}
 }
@@ -91,6 +86,12 @@ func parseBuildInfo() buildInfo {
 		switch key {
 		case "version":
 			info.version = val
+		case "commit":
+			info.commit = val
+		case "buildtime":
+			info.buildTime = val
+		case "dirty":
+			info.dirty = val == "true"
 		case "origin":
 			info.origin = val
 		case "branch":
@@ -101,32 +102,6 @@ func parseBuildInfo() buildInfo {
 			}
 		case "fork":
 			info.isFork = val == "true"
-		}
-	}
-	return info
-}
-
-func getVCSInfo() vcsInfo {
-	info := vcsInfo{
-		revision:  "unknown",
-		buildTime: "unknown",
-	}
-	buildInfo, ok := debug.ReadBuildInfo()
-	if !ok {
-		return info
-	}
-	for _, s := range buildInfo.Settings {
-		switch s.Key {
-		case "vcs.revision":
-			if len(s.Value) > 8 {
-				info.revision = s.Value[:8]
-			} else {
-				info.revision = s.Value
-			}
-		case "vcs.time":
-			info.buildTime = s.Value
-		case "vcs.modified":
-			info.dirty = s.Value == "true"
 		}
 	}
 	return info

--- a/scripts/make-tarball
+++ b/scripts/make-tarball
@@ -17,7 +17,7 @@ fi
 readonly bin="$GOPATH/bin/$command"
 readonly target="/tmp/$LOGNAME/$command.tar.gz"
 
-CGO_ENABLED=0 go install ./cmd/$command
+CGO_ENABLED=0 go install -buildvcs=true ./cmd/$command
 
 strip -o "$bin~" "$bin"
 if cmp -s "$bin~" "$bin"; then


### PR DESCRIPTION
## Fix: `Commit` and `Built` show `unknown`

### Problem — Workspace builds lose VCS stamping

`<binary> -version` showed `Commit: unknown`, `Built: unknown` when the repo was built inside a Go workspace.

Sample log:
`Startup: v0.13.0-8-g392198aa (commit: unknown, origin: rgooch/Dominator, behind: up to date, built: unknown, go: go1.26.2)`

**Cause:** `lib/version` reads `vcs.revision`, `vcs.time`, and `vcs.modified` from `runtime/debug.ReadBuildInfo()`. Go suppresses all `vcs.*` settings in workspace mode, so those fields came back blank.

**Fix:**Adds `-buildvcs=true` to every `go build` and `go install` invocation in `Makefile` and `scripts/make-tarball` to force use vcs info while building. This enables  to embed vcs info explicitly.