### PR TITLE
added support to for referenced objects and usage in the objectserver metrics

### DIFF
--- a/cmd/imageserver/main.go
+++ b/cmd/imageserver/main.go
@@ -83,6 +83,10 @@ func main() {
 	if err := setupserver.SetupTlsWithParams(params); err != nil {
 		logger.Fatalln(err)
 	}
+	objectServerMetricsDir, err := tricorder.RegisterDirectory("/objectserver")
+	if err != nil {
+		logger.Fatalln(err)
+	}
 	objSrv, err := filesystem.NewObjectServerWithConfigAndParams(
 		filesystem.Config{
 			BaseDirectory:     *objectDir,
@@ -90,7 +94,8 @@ func main() {
 			LockLogTimeout:    *lockLogTimeout,
 		},
 		filesystem.Params{
-			Logger: logger,
+			Logger:           logger,
+			MetricsDirectory: objectServerMetricsDir,
 		})
 	if err != nil {
 		logger.Fatalf("Cannot create ObjectServer: %s\n", err)

--- a/lib/objectserver/filesystem/api.go
+++ b/lib/objectserver/filesystem/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Cloud-Foundations/Dominator/lib/log"
 	"github.com/Cloud-Foundations/Dominator/lib/log/debuglogger"
 	"github.com/Cloud-Foundations/Dominator/lib/objectserver"
+	"github.com/Cloud-Foundations/tricorder/go/tricorder"
 )
 
 var (
@@ -67,7 +68,8 @@ type ObjectServer struct {
 }
 
 type Params struct {
-	Logger log.DebugLogger
+	Logger           log.DebugLogger
+	MetricsDirectory *tricorder.DirectorySpec
 }
 
 func NewObjectServer(baseDir string, logger log.Logger) (

--- a/lib/objectserver/filesystem/metrics.go
+++ b/lib/objectserver/filesystem/metrics.go
@@ -1,0 +1,49 @@
+package filesystem
+
+import (
+	"github.com/Cloud-Foundations/tricorder/go/tricorder"
+	"github.com/Cloud-Foundations/tricorder/go/tricorder/units"
+)
+
+func (objSrv *ObjectServer) registerMetrics(
+	dir *tricorder.DirectorySpec) error {
+	if err := dir.RegisterMetric("referenced-object-bytes",
+		&objSrv.referencedBytes,
+		units.Byte,
+		"bytes consumed by referenced objects"); err != nil {
+		return err
+	}
+	if err := dir.RegisterMetric("unreferenced-object-bytes",
+		&objSrv.unreferencedBytes,
+		units.Byte,
+		"bytes consumed by unreferenced objects"); err != nil {
+		return err
+	}
+	if err := dir.RegisterMetric("referenced-utilisation-percent",
+		func() float64 {
+			return objSrv.utilisationPercent(objSrv.referencedBytes)
+		},
+		units.None,
+		"referenced object bytes as percent of filesystem capacity",
+	); err != nil {
+		return err
+	}
+	if err := dir.RegisterMetric("unreferenced-utilisation-percent",
+		func() float64 {
+			return objSrv.utilisationPercent(objSrv.unreferencedBytes)
+		},
+		units.None,
+		"unreferenced object bytes as percent of filesystem capacity",
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (objSrv *ObjectServer) utilisationPercent(bytes uint64) float64 {
+	_, capacity, err := objSrv.getSpaceMetrics()
+	if err != nil || capacity == 0 {
+		return 0
+	}
+	return float64(bytes) * 100 / float64(capacity)
+}

--- a/lib/objectserver/filesystem/new.go
+++ b/lib/objectserver/filesystem/new.go
@@ -52,5 +52,10 @@ func newObjectServer(config Config, params Params) (*ObjectServer, error) {
 			Logger:        prefixlogger.New("ObjectServer: ", params.Logger),
 			LogTimeout:    config.LockLogTimeout,
 		})
+	if params.MetricsDirectory != nil {
+		if err := objSrv.registerMetrics(params.MetricsDirectory); err != nil {
+			return nil, err
+		}
+	}
 	return objSrv, nil
 }


### PR DESCRIPTION
Add object usage metrics to the imageserver objectserver

Adds 4 tricorder metrics under /imageserver/objectserver/ so we can alert on object utilization

  - referenced-object-bytes
  - referenced-utilization-percent
  - unreferenced-object-bytes
  - unreferenced-utilization-percent