### PR TITLE
imaginator: rpm: handle large packages in ListCommand

### DIFF
--- a/cmd/imaginator/conf.json
+++ b/cmd/imaginator/conf.json
@@ -172,7 +172,7 @@
 		    "rpm",
 		    "-qa",
 		    "--queryformat",
-		    "%{NAME} %{VERSION}_%{RELEASE} %{SIZE}\n"
+		    "%{NAME} %{VERSION}_%{RELEASE} %{LONGSIZE}\n"
 		]
 	    },
 	    "RemoveCommand": [


### PR DESCRIPTION
Building an image which uses the rpm package manager and has installed a sufficiently large package (size larger than UINT32_MAX) currently fails with:

Error building image: error listing packages: malformed size: (none)

This happens because the command that is used under the hood to list packages in rpm-based distros uses the %{SIZE} parameter to extract the size of a package, and empirically this appears to report (none) for packages whose sizes don't fit into 32 bits. Fix this issue by using %{LONGSIZE} instead, which appears to report an actual size for these larger packages.