### PR TITLE
imagebuilder: introduce Variant field for per-pin image directories

### DIFF
--- a/cmd/imaginator/README.md
+++ b/cmd/imaginator/README.md
@@ -118,6 +118,10 @@ fields:
 - `Owners`: optional object with a list of `Groups` and `Users` who will have
             ownership of the built images
 - `PackagerType`: the name of the packager type to use
+- `Variant`: an optional expression expanded against the build request's
+             `Variables` map. When non-empty, the expanded value is inserted
+             between the stream name and the timestamp when the built image
+             is published
 
 ### Cache configuration
 It's considered an anti-pattern to use the *Imaginator* to compile code; instead

--- a/cmd/imaginator/conf.json
+++ b/cmd/imaginator/conf.json
@@ -54,7 +54,8 @@
 	    ],
 	    "ImageFilterUrl": "file:///etc/imaginator/filters/Debian-10",
 	    "ImageTriggersUrl": "file:///etc/imaginator/triggers/Debian-10",
-	    "PackagerType": "deb"
+	    "PackagerType": "deb",
+	    "Variant": "$EPOCH"
 	},
 	"bootstrap/Debian-10/i386": {
 	    "BootstrapCommand": [

--- a/imagebuilder/builder/api.go
+++ b/imagebuilder/builder/api.go
@@ -37,7 +37,7 @@ type environmentGetter interface {
 
 type imageBuilder interface {
 	build(b *Builder, client srpc.ClientI, request proto.BuildImageRequest,
-		buildLog buildLogger) (*image.Image, error)
+		buildLog buildLogger) (*image.Image, string, error)
 }
 
 // Other private types.
@@ -63,6 +63,7 @@ type bootstrapStream struct {
 	ImageTriggersUrl string
 	Owners           OwnersType
 	PackagerType     string
+	Variant          string
 }
 
 type buildResultType struct {
@@ -140,6 +141,8 @@ type manifestConfigType struct {
 	SourceImageBuildVariables map[string]string `json:",omitempty"`
 	SourceImageGitCommitId    string            `json:",omitempty"`
 	SourceImageTagsToMatch    tags.MatchTags    `json:",omitempty"`
+	Variables                 map[string]string `json:",omitempty"`
+	Variant                   string            `json:",omitempty"`
 }
 
 type masterConfigurationType struct {
@@ -167,6 +170,7 @@ type manifestType struct {
 	mtimesCopyAddFilter *filter.Filter
 	mtimesCopyFilter    *filter.Filter
 	sourceImageInfo     *sourceImageInfoType
+	variant             string
 }
 
 type packagerType struct {
@@ -317,7 +321,7 @@ func LoadWithOptionsAndParams(options BuilderOptions,
 
 func (b *Builder) BuildImage(request proto.BuildImageRequest,
 	authInfo *srpc.AuthInformation,
-	logWriter io.Writer) (*image.Image, string, error) {
+	logWriter io.Writer) (*image.Image, string, string, error) {
 	return b.buildImage(request, authInfo, logWriter)
 }
 

--- a/imagebuilder/builder/bootstrapImage.go
+++ b/imagebuilder/builder/bootstrapImage.go
@@ -92,19 +92,25 @@ func makeTempDirectory(dir, prefix string) (string, error) {
 
 func (stream *bootstrapStream) build(b *Builder, client srpc.ClientI,
 	request proto.BuildImageRequest,
-	buildLog buildLogger) (*image.Image, error) {
+	buildLog buildLogger) (*image.Image, string, error) {
 	startTime := time.Now()
 	args := make([]string, 0, len(stream.BootstrapCommand))
 	rootDir, err := makeTempDirectory("",
 		strings.Replace(request.StreamName, "/", "_", -1))
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer os.RemoveAll(rootDir)
 	fmt.Fprintf(buildLog, "Created image working directory: %s\n", rootDir)
 	vg := variablesGetter(request.Variables).copy()
 	vg.add("dir", rootDir)
 	request.Variables = vg
+	variant := expand.Expression(stream.Variant, func(name string) string {
+		return vg[name]
+	})
+	if variant != "" {
+		request.StreamName = request.StreamName + "/" + variant
+	}
 	for _, exp := range stream.BootstrapCommand {
 		arg := expand.Expression(exp, func(name string) string {
 			return vg[name]
@@ -117,7 +123,7 @@ func (stream *bootstrapStream) build(b *Builder, client srpc.ClientI,
 	}
 	g, err := newNamespaceTarget()
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer g.Quit()
 	ctx, cancel := makeContext2(b.maximumBuildDuration,
@@ -126,29 +132,30 @@ func (stream *bootstrapStream) build(b *Builder, client srpc.ClientI,
 	err = runInTarget(ctx, g, nil, buildLog, buildLog, "", nil,
 		args[0], args[1:]...)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	} else {
 		g.Run(func() { err = setupMounts(rootDir, nil) })
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		packager := b.packagerTypes[stream.PackagerType]
 		if err := packager.writePackageInstaller(rootDir); err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		if err := clearResolvConf(ctx, g, buildLog, rootDir); err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		buildDuration := time.Since(startTime)
 		fmt.Fprintf(buildLog, "\nBuild time: %s\n",
 			format.Duration(buildDuration))
 		if err := cleanPackages(ctx, g, rootDir, buildLog); err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		return packImage(ctx, g, client, request, rootDir,
+		img, err := packImage(ctx, g, client, request, rootDir,
 			stream.Filter, nil, nil, stream.imageFilter, stream.Owners,
 			stream.imageTags, stream.imageTriggers, b.mtimesCopyFilter,
 			buildLog, b.logger)
+		return img, variant, err
 	}
 }
 

--- a/imagebuilder/builder/build.go
+++ b/imagebuilder/builder/build.go
@@ -97,17 +97,17 @@ func (b *Builder) checkToAutoExtend() bool {
 
 func (b *Builder) build(client srpc.ClientI, request proto.BuildImageRequest,
 	authInfo *srpc.AuthInformation,
-	logWriter io.Writer) (*image.Image, string, error) {
+	logWriter io.Writer) (*image.Image, string, string, error) {
 	startTime := time.Now()
 	builder, err := b.getImageBuilderWithReload(request.StreamName)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	if builder == nil {
-		return nil, "", errors.New("unknown stream: " + request.StreamName)
+		return nil, "", "", errors.New("unknown stream: " + request.StreamName)
 	}
 	if err := b.checkPermission(builder, request, authInfo); err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	buildLogBuffer := &bytes.Buffer{}
 	buildInfo := &currentBuildInfo{
@@ -130,8 +130,8 @@ func (b *Builder) build(client srpc.ClientI, request proto.BuildImageRequest,
 		fmt.Fprintf(buildLog, "Building: %s for: %s\n",
 			request.StreamName, authInfo.Username)
 	}
-	img, name, err := b.buildWithLogger(builder, client, request, authInfo,
-		startTime, &buildInfo.slaveAddress, buildLog)
+	img, name, variant, err := b.buildWithLogger(builder, client, request,
+		authInfo, startTime, &buildInfo.slaveAddress, buildLog)
 	finishTime := time.Now()
 	b.buildResultsLock.Lock()
 	defer b.buildResultsLock.Unlock()
@@ -158,54 +158,54 @@ func (b *Builder) build(client srpc.ClientI, request proto.BuildImageRequest,
 		b.logger.Printf("Built image: %s in %s\n",
 			name, format.Duration(finishTime.Sub(startTime)))
 	}
-	return img, name, err
+	return img, name, variant, err
 }
 
 func (b *Builder) buildImage(request proto.BuildImageRequest,
 	authInfo *srpc.AuthInformation,
-	logWriter io.Writer) (*image.Image, string, error) {
+	logWriter io.Writer) (*image.Image, string, string, error) {
 	b.disableLock.RLock()
 	disableUntil := b.disableBuildRequestsUntil
 	b.disableLock.RUnlock()
 	if duration := time.Until(disableUntil); duration > 0 {
-		return nil, "", fmt.Errorf("builds disabled until %s (for %s)",
+		return nil, "", "", fmt.Errorf("builds disabled until %s (for %s)",
 			disableUntil.Format(format.TimeFormatSeconds),
 			format.Duration(duration))
 	}
 	if request.ExpiresIn < b.minimumExpiration {
-		return nil, "", fmt.Errorf("minimum expiration duration is %s",
+		return nil, "", "", fmt.Errorf("minimum expiration duration is %s",
 			format.Duration(b.minimumExpiration))
 	}
 	if err := b.WaitForStreamsLoaded(time.Minute); err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	client, err := dialServer(b.imageServerAddress, time.Minute)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	defer client.Close()
-	img, name, err := b.build(client, request, authInfo, logWriter)
+	img, name, variant, err := b.build(client, request, authInfo, logWriter)
 	if request.ReturnImage {
-		return img, "", err
+		return img, "", variant, err
 	}
-	return nil, name, err
+	return nil, name, variant, err
 }
 
 func (b *Builder) buildLocal(builder imageBuilder, client srpc.ClientI,
 	request proto.BuildImageRequest, authInfo *srpc.AuthInformation,
-	buildLog buildLogger) (*image.Image, error) {
+	buildLog buildLogger) (*image.Image, string, error) {
 	// Check the namespace to make sure it hasn't changed. This is to catch
 	// golang bugs.
 	currentNamespace, err := getNamespace()
 	if err != nil {
 		fmt.Fprintln(buildLog, err)
-		return nil, err
+		return nil, "", err
 	}
 	if currentNamespace != b.initialNamespace {
 		err := fmt.Errorf("namespace changed from: %s to: %s",
 			b.initialNamespace, currentNamespace)
 		fmt.Fprintln(buildLog, err)
-		return nil, err
+		return nil, "", err
 	}
 	if authInfo == nil {
 		b.logger.Printf("Auto building image for stream: %s\n",
@@ -214,17 +214,17 @@ func (b *Builder) buildLocal(builder imageBuilder, client srpc.ClientI,
 		b.logger.Printf("%s requested building image for stream: %s\n",
 			authInfo.Username, request.StreamName)
 	}
-	img, err := builder.build(b, client, request, buildLog)
+	img, variant, err := builder.build(b, client, request, buildLog)
 	if err != nil {
 		fmt.Fprintf(buildLog, "Error building image: %s\n", err)
-		return nil, err
+		return nil, "", err
 	}
-	return img, nil
+	return img, variant, nil
 }
 
 func (b *Builder) buildOnSlave(client srpc.ClientI,
 	request proto.BuildImageRequest, authInfo *srpc.AuthInformation,
-	slaveAddress *string, buildLog buildLogger) (*image.Image, error) {
+	slaveAddress *string, buildLog buildLogger) (*image.Image, string, error) {
 	request.DisableRecursiveBuild = true
 	request.ReturnImage = true
 	request.StreamBuildLog = true
@@ -244,7 +244,7 @@ func (b *Builder) buildOnSlave(client srpc.ClientI,
 	}
 	slave, err := b.slaveDriver.GetSlaveWithTimeout(b.createSlaveTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("error getting slave: %s", err)
+		return nil, "", fmt.Errorf("error getting slave: %s", err)
 	}
 	*slaveAddress = slave.GetClientAddress()
 	keepSlave := false
@@ -273,7 +273,7 @@ func (b *Builder) buildOnSlave(client srpc.ClientI,
 	if err != nil {
 		if reply.NeedSourceImage {
 			keepSlave = true
-			return nil, &BuildErrorType{
+			return nil, "", &BuildErrorType{
 				error:                     err.Error(),
 				NeedSourceImage:           true,
 				SourceImage:               reply.SourceImage,
@@ -281,14 +281,14 @@ func (b *Builder) buildOnSlave(client srpc.ClientI,
 				SourceImageGitCommitId:    reply.SourceImageGitCommitId,
 			}
 		}
-		return nil, err
+		return nil, "", err
 	}
-	return reply.Image, nil
+	return reply.Image, reply.Variant, nil
 }
 
 func (b *Builder) buildSomewhere(builder imageBuilder, client srpc.ClientI,
 	request proto.BuildImageRequest, authInfo *srpc.AuthInformation,
-	slaveAddress *string, buildLog buildLogger) (*image.Image, error) {
+	slaveAddress *string, buildLog buildLogger) (*image.Image, string, error) {
 	if b.slaveDriver == nil {
 		return b.buildLocal(builder, client, request, authInfo, buildLog)
 	} else {
@@ -299,14 +299,14 @@ func (b *Builder) buildSomewhere(builder imageBuilder, client srpc.ClientI,
 func (b *Builder) buildWithLogger(builder imageBuilder, client srpc.ClientI,
 	request proto.BuildImageRequest, authInfo *srpc.AuthInformation,
 	startTime time.Time, slaveAddress *string,
-	buildLog buildLogger) (*image.Image, string, error) {
-	img, err := b.buildSomewhere(builder, client, request, authInfo,
+	buildLog buildLogger) (*image.Image, string, string, error) {
+	img, variant, err := b.buildSomewhere(builder, client, request, authInfo,
 		slaveAddress, buildLog)
 	if err != nil {
 		var buildError *BuildErrorType
 		if stderrors.As(err, &buildError) && buildError.NeedSourceImage {
 			if request.DisableRecursiveBuild {
-				return nil, "", err
+				return nil, "", "", err
 			}
 			// Try to build source image.
 			expiresIn := time.Hour
@@ -322,33 +322,36 @@ func (b *Builder) buildWithLogger(builder imageBuilder, client srpc.ClientI,
 				StreamName:   buildError.SourceImage,
 				Variables:    variables,
 			}
-			if _, _, e := b.build(client, sourceReq, nil, buildLog); e != nil {
-				return nil, "", e
+			if _, _, _, e := b.build(client, sourceReq, nil, buildLog); e != nil {
+				return nil, "", "", e
 			}
-			img, err = b.buildSomewhere(builder, client, request, authInfo,
-				slaveAddress, buildLog)
+			img, variant, err = b.buildSomewhere(builder, client, request,
+				authInfo, slaveAddress, buildLog)
 		}
 	}
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	if request.ReturnImage {
-		return img, "", nil
+		return img, "", variant, nil
 	}
 	if authInfo != nil {
 		img.CreatedFor = authInfo.Username
 	}
+	if variant != "" {
+		request.StreamName = request.StreamName + "/" + variant
+	}
 	uploadStartTime := time.Now()
 	if name, err := addImage(client, request, img); err != nil {
 		fmt.Fprintln(buildLog, err)
-		return nil, "", err
+		return nil, "", "", err
 	} else {
 		finishTime := time.Now()
 		fmt.Fprintf(buildLog,
 			"Uploaded %s in %s, total build duration: %s\n",
 			name, format.Duration(finishTime.Sub(uploadStartTime)),
 			format.Duration(finishTime.Sub(startTime)))
-		return img, name, nil
+		return img, name, variant, nil
 	}
 }
 
@@ -495,7 +498,7 @@ func (b *Builder) rebuildImage(client srpc.ClientI, streamName string,
 		b.extendImage(client, streamName, expiresIn)
 		return
 	}
-	_, _, err := b.build(client, proto.BuildImageRequest{
+	_, _, _, err := b.build(client, proto.BuildImageRequest{
 		StreamName: streamName,
 		ExpiresIn:  expiresIn,
 	},

--- a/imagebuilder/builder/image.go
+++ b/imagebuilder/builder/image.go
@@ -42,11 +42,11 @@ type gitInfoType struct {
 
 func (stream *imageStreamType) build(b *Builder, client srpc.ClientI,
 	request proto.BuildImageRequest, buildLog buildLogger) (
-	*image.Image, error) {
+	*image.Image, string, error) {
 	manifestDirectory, gitInfo, err := stream.getManifest(b, request.StreamName,
 		request.GitBranch, request.Variables, buildLog)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer os.RemoveAll(manifestDirectory)
 	ctx, cancel := makeContext2(b.maximumBuildDuration,
@@ -57,7 +57,7 @@ func (stream *imageStreamType) build(b *Builder, client srpc.ClientI,
 		sourceDir := filepath.Join(b.cache.BaseDirectory,
 			filepath.Clean(request.StreamName))
 		if err := os.MkdirAll(sourceDir, fsutil.DirPerms); err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		bindMounts = append(bindMounts, bindMountType{
 			source:   sourceDir,
@@ -65,20 +65,21 @@ func (stream *imageStreamType) build(b *Builder, client srpc.ClientI,
 			writable: true,
 		})
 	}
-	img, err := buildImageFromManifest(ctx, client, manifestDirectory, request,
-		bindMounts, stream, gitInfo, b.mtimesCopyFilter, buildLog, b.logger)
+	img, variant, err := buildImageFromManifest(ctx, client, manifestDirectory,
+		request, bindMounts, stream, gitInfo, b.mtimesCopyFilter, buildLog,
+		b.logger)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if b.cache.BaseDirectory != "" && b.cache.MountPoint != "" {
 		sourceDir := filepath.Join(b.cache.BaseDirectory,
 			filepath.Clean(request.StreamName))
 		err := trimDirectory(sourceDir, b.cache.SizeLimit, buildLog)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 	}
-	return img, nil
+	return img, variant, nil
 }
 
 func (stream *imageStreamType) getenv() map[string]string {
@@ -284,15 +285,15 @@ func buildImageFromManifest(ctx context.Context, client srpc.ClientI,
 	manifestDir string, request proto.BuildImageRequest,
 	bindMounts []bindMountType, envGetter environmentGetter,
 	gitInfo *gitInfoType, mtimesCopyFilter *filter.Filter,
-	buildLog buildLogger, logger log.Logger) (*image.Image, error) {
+	buildLog buildLogger, logger log.Logger) (*image.Image, string, error) {
 	// First load all the various manifest files (fail early on error).
 	computedFilesList, addComputedFiles, err := loadComputedFiles(manifestDir)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	imageFilter, addFilter, err := loadFilter(manifestDir)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if imageFilter != nil {
 		if lines := imageFilter.ListUnoptimised(); len(lines) > 0 {
@@ -305,20 +306,20 @@ func buildImageFromManifest(ctx context.Context, client srpc.ClientI,
 	}
 	owners, err := loadOwners(manifestDir)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	tgs, err := loadTags(manifestDir)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	imageTriggers, addTriggers, err := loadTriggers(manifestDir)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	rootDir, err := makeTempDirectory("",
 		strings.Replace(request.StreamName, "/", "_", -1)+".root")
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer os.RemoveAll(rootDir)
 	fmt.Fprintf(buildLog, "Created image working directory: %s\n", rootDir)
@@ -333,11 +334,14 @@ func buildImageFromManifest(ctx context.Context, client srpc.ClientI,
 		request.MaxSourceAge, rootDir, bindMounts, false, vGetter, buildLog,
 		logger)
 	if err != nil {
-		return nil, err
+		return nil, "", err
+	}
+	if manifest.variant != "" {
+		request.StreamName = request.StreamName + "/" + manifest.variant
 	}
 	ctimeResolution, err := getCtimeResolution()
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	time.Sleep(ctimeResolution)
 	fmt.Fprintf(buildLog, "Waited %s (Ctime resolution)\n",
@@ -346,11 +350,11 @@ func buildImageFromManifest(ctx context.Context, client srpc.ClientI,
 		if fi.IsDir() {
 			testsDir := filepath.Join(rootDir, "tests", request.StreamName)
 			if err := os.MkdirAll(testsDir, fsutil.DirPerms); err != nil {
-				return nil, err
+				return nil, "", err
 			}
 			err := copyFiles(manifestDir, "tests", testsDir, buildLog)
 			if err != nil {
-				return nil, err
+				return nil, "", err
 			}
 		}
 	}
@@ -380,14 +384,14 @@ func buildImageFromManifest(ctx context.Context, client srpc.ClientI,
 	}
 	g, err := newNamespaceTargetWithMounts(rootDir, nil)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer g.Quit()
 	img, err := packImage(ctx, g, client, request, rootDir, manifest.filter,
 		manifest.sourceImageInfo.treeCache, computedFilesList, imageFilter,
 		owners, tgs, imageTriggers, mtimesCopyFilter, buildLog, logger)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if gitInfo != nil {
 		img.BuildBranch = gitInfo.branch
@@ -395,7 +399,7 @@ func buildImageFromManifest(ctx context.Context, client srpc.ClientI,
 		img.BuildGitUrl = gitInfo.gitUrl
 	}
 	img.SourceImage = manifest.sourceImageInfo.imageName
-	return img, nil
+	return img, manifest.variant, nil
 }
 
 func buildImageFromManifestAndUpload(ctx context.Context, client srpc.ClientI,
@@ -405,7 +409,7 @@ func buildImageFromManifestAndUpload(ctx context.Context, client srpc.ClientI,
 		StreamName: streamName,
 		ExpiresIn:  expiresIn,
 	}
-	img, err := buildImageFromManifest(
+	img, variant, err := buildImageFromManifest(
 		ctx,
 		client,
 		options.ManifestDirectory,
@@ -423,6 +427,9 @@ func buildImageFromManifestAndUpload(ctx context.Context, client srpc.ClientI,
 		logger)
 	if err != nil {
 		return nil, "", err
+	}
+	if variant != "" {
+		request.StreamName = request.StreamName + "/" + variant
 	}
 	name, err := addImage(client, request, img)
 	if err != nil {
@@ -624,7 +631,7 @@ func loadTriggers(manifestDir string) (*triggers.Triggers, bool, error) {
 	}
 }
 
-func unpackImage(client srpc.ClientI, streamName, buildCommitId string,
+func unpackImage(client srpc.ClientI, streamName, variant, buildCommitId string,
 	sourceImageTagsToMatch tags.MatchTags, maxSourceAge time.Duration,
 	rootDir string, buildLog io.Writer, logger log.Logger) (
 	*sourceImageInfoType, error) {
@@ -632,16 +639,20 @@ func unpackImage(client srpc.ClientI, streamName, buildCommitId string,
 	if err != nil {
 		return nil, err
 	}
-	imageName, sourceImage, err := getLatestImage(client, streamName,
+	searchDir := streamName
+	if variant != "" {
+		searchDir += "/" + variant
+	}
+	imageName, sourceImage, err := getLatestImage(client, searchDir,
 		buildCommitId, sourceImageTagsToMatch, buildLog, logger)
 	if err != nil {
 		return nil, err
 	}
 	var specifiedStream string
 	if buildCommitId == "" {
-		specifiedStream = streamName
+		specifiedStream = searchDir
 	} else {
-		specifiedStream = streamName + "@gitCommitId:" + buildCommitId
+		specifiedStream = searchDir + "@gitCommitId:" + buildCommitId
 	}
 	if len(sourceImageTagsToMatch) > 0 {
 		specifiedStream += fmt.Sprintf("@tags:%v", sourceImageTagsToMatch)

--- a/imagebuilder/builder/processManifest.go
+++ b/imagebuilder/builder/processManifest.go
@@ -108,6 +108,20 @@ func readManifestFile(manifestDir string, envGetter environmentGetter) (
 	if envGetter == nil {
 		return manifestConfig, nil
 	}
+	// Manifest Variables are low-priority defaults; envGetter overrides.
+	if len(manifestConfig.Variables) > 0 {
+		merged := make(map[string]string,
+			len(envGetter.getenv())+len(manifestConfig.Variables))
+		for key, expr := range manifestConfig.Variables {
+			merged[key] = expand.Expression(expr, func(name string) string {
+				return envGetter.getenv()[name]
+			})
+		}
+		for key, value := range envGetter.getenv() {
+			merged[key] = value
+		}
+		envGetter = variablesGetter(merged)
+	}
 	manifestConfig.SourceImage = expand.Expression(manifestConfig.SourceImage,
 		func(name string) string {
 			return envGetter.getenv()[name]
@@ -141,6 +155,18 @@ func readManifestFile(manifestDir string, envGetter environmentGetter) (
 			delete(manifestConfig.SourceImageTagsToMatch, key)
 		}
 	}
+	manifestConfig.Variant = expand.Expression(manifestConfig.Variant,
+		func(name string) string {
+			return envGetter.getenv()[name]
+		})
+	// Propagate the expanded Variant to source rebuilds as $VARIANT.
+	if manifestConfig.Variant != "" {
+		if manifestConfig.SourceImageBuildVariables == nil {
+			manifestConfig.SourceImageBuildVariables = map[string]string{}
+		}
+		manifestConfig.SourceImageBuildVariables["VARIANT"] =
+			manifestConfig.Variant
+	}
 	return manifestConfig, nil
 }
 
@@ -167,6 +193,7 @@ func unpackImageAndProcessManifest(ctx context.Context, client srpc.ClientI,
 		}
 	}
 	sourceImageInfo, err := unpackImage(client, manifestConfig.SourceImage,
+		manifestConfig.Variant,
 		manifestConfig.SourceImageGitCommitId,
 		manifestConfig.SourceImageTagsToMatch,
 		maxSourceAge, rootDir, buildLog, logger)
@@ -198,6 +225,7 @@ func unpackImageAndProcessManifest(ctx context.Context, client srpc.ClientI,
 		mtimesCopyAddFilter: mtimesCopyAddFilter,
 		mtimesCopyFilter:    mtimesCopyFilter,
 		sourceImageInfo:     sourceImageInfo,
+		variant:             manifestConfig.Variant,
 	}, nil
 }
 

--- a/imagebuilder/rpcd/buildImage.go
+++ b/imagebuilder/rpcd/buildImage.go
@@ -40,8 +40,8 @@ func (t *srpcType) BuildImage(conn *srpc.Conn) error {
 	} else {
 		logWriter = buildLogBuffer
 	}
-	image, name, err := t.builder.BuildImage(request, conn.GetAuthInformation(),
-		logWriter)
+	image, name, variant, err := t.builder.BuildImage(request,
+		conn.GetAuthInformation(), logWriter)
 	if f, ok := logWriter.(flusher); ok {
 		// Ensure all data are flushed and no background flush will happen.
 		if err := f.flush(); err != nil {
@@ -51,6 +51,7 @@ func (t *srpcType) BuildImage(conn *srpc.Conn) error {
 	reply := proto.BuildImageResponse{
 		Image:       image,
 		ImageName:   name,
+		Variant:     variant,
 		BuildLog:    buildLogBuffer.Bytes(),
 		ErrorString: errors.ErrorToString(err),
 	}

--- a/proto/imaginator/messages.go
+++ b/proto/imaginator/messages.go
@@ -27,6 +27,7 @@ type BuildImageResponse struct {
 	SourceImage               string
 	SourceImageBuildVariables map[string]string
 	SourceImageGitCommitId    string
+	Variant                   string
 }
 
 type DisableAutoBuildsRequest struct {

--- a/user-guide/image-manifest.md
+++ b/user-guide/image-manifest.md
@@ -51,6 +51,10 @@ fields:
                             image
 - `SourceImageTagsToMatch`: key:[value] tag matches to use when searching for a
                             source image
+- `Variant`: an optional expression expanded against the merged build
+             variables. When non-empty, the expanded value is appended to
+             `SourceImage` when looking up the source image and to the
+             current stream name when publishing the built image
 
 Other fields may be present and they will be ignored by the
 *[imaginator](../cmd/imaginator/README.md)*. This is typically used to store


### PR DESCRIPTION
Add an optional Variant expression to bootstrap stream configs and image manifests. When non-empty, the expanded value becomes a path segment between the stream name and the timestamp: <stream>/<variant>/<timestamp>

Two builds of the same stream with different Variables values land in separate imageserver directories, so a lookup for one pin cannot silently match an image built under a different pin.

Backwards-compatible: when Variant is empty or absent, the traditional flat layout is used.